### PR TITLE
Add vsphere StorageClass for our CI

### DIFF
--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -1,9 +1,10 @@
 StorageClass:
-  FromExistingClassName: standard-csi
+  # TODO: use the default storage class created by the driver
+  FromFile: storageclass-ci.yaml
 SnapshotClass:
   FromName: true
 DriverInfo:
-  Name: pd.csi.storage.gke.io
+  Name: csi.vsphere.vmware.com
   SupportedFsType:
     xfs: {}
     ext4: {}
@@ -20,8 +21,6 @@ DriverInfo:
     fsGroup: true
     block: true
     exec: true
-    # The driver does support volume limits, however, we disable
-    # the capability to avoid creating 100+ volumes in a single test.
     volumeLimits: false
     controllerExpansion: true
     nodeExpansion: true

--- a/test/e2e/storageclass-ci.yaml
+++ b/test/e2e/storageclass-ci.yaml
@@ -1,0 +1,14 @@
+# vSphere CSI driver operator cannot create a StorageClass yet.
+# Use this StorageClass as a template for CI tests, pointing to
+# our datastore.
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-ci
+parameters:
+  # Datastore URL in OCP CI
+  datastoreurl: ds:///vmfs/volumes/vsan:86c7dbc3da924855-b20d5cd1f4eec976/
+provisioner: csi.vsphere.vmware.com
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
The operator does not create a default storage class yet. Use a pre-defined one for CI.

In addition, update the manifest to vSphere
