### PR TITLE
Disable unsupported features

### DIFF
--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -22,6 +22,6 @@ DriverInfo:
     block: true
     exec: true
     volumeLimits: false
-    controllerExpansion: true
-    nodeExpansion: true
-    snapshotDataSource: true
+    controllerExpansion: false
+    nodeExpansion: false
+    snapshotDataSource: false


### PR DESCRIPTION
Snapshots and expansion are not supported by the CSI driver yet.

@openshift/storage 