### PR TITLE
Bug 1947776: fixed updateStrategy of the DaemonSet

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -9,6 +9,10 @@ spec:
   selector:
     matchLabels:
       app: vmware-vsphere-csi-driver-node
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       labels:

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -393,6 +393,10 @@ spec:
   selector:
     matchLabels:
       app: vmware-vsphere-csi-driver-node
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       labels:


### PR DESCRIPTION
This pull request add `update strategy` field to the `daemon set` template. 

The commit sets the default value to `10 %`. 

fixes [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1947776) [vSphere csi driver operator] Should allow more nodes to be updated simultaneously for speeding up cluster upgrade


