### PR TITLE
Bug 1953810: Update CSI driver configuration to the latest version

### DIFF
--- a/assets/vsphere_features_config.yaml
+++ b/assets/vsphere_features_config.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 data:
   "csi-migration": "false" # csi-migration feature is only available for vSphere 7.0U1
+  "csi-auth-check": "true"
+  "online-volume-extend": "true"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -1308,6 +1308,8 @@ func vsphere_cloud_configYaml() (*asset, error) {
 var _vsphere_features_configYaml = []byte(`apiVersion: v1
 data:
   "csi-migration": "false" # csi-migration feature is only available for vSphere 7.0U1
+  "csi-auth-check": "true"
+  "online-volume-extend": "true"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1953810

After these fixes, we no longer see issues we saw in - https://github.com/openshift/vmware-vsphere-csi-driver-operator/pull/9 and using storage policy works as expected. 