### PR TITLE
Add cluster CA bundle

### DIFF
--- a/assets/ca_configmap.yaml
+++ b/assets/ca_configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    # This label ensures that the OpenShift Certificate Authority bundle
+    # is added to the ConfigMap.
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: vsphere-csi-driver-trusted-ca-bundle
+  namespace: openshift-cluster-csi-drivers

--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -65,6 +65,9 @@ spec:
             - name: vsphere-csi-config-volume
               mountPath: /etc/kubernetes/vsphere-csi-config/
               readOnly: true
+            - name: trusted-ca-bundle
+              mountPath: /etc/pki/ca-trust/extracted/pem
+              readOnly: true
           resources:
             requests:
               memory: 50Mi
@@ -240,3 +243,9 @@ spec:
         - name: metrics-serving-cert
           secret:
             secretName: vmware-vsphere-csi-driver-controller-metrics-serving-cert
+        - name: trusted-ca-bundle
+          configMap:
+            name: vsphere-csi-driver-trusted-ca-bundle
+            items:
+              - key: ca-bundle.crt
+                path: tls-ca-bundle.pem

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -62,6 +62,9 @@ spec:
               mountPath: /csi
             - name: device-dir
               mountPath: /dev
+            - name: trusted-ca-bundle
+              mountPath: /etc/pki/ca-trust/extracted/pem
+              readOnly: true
           ports:
             - name: healthz
               # Due to hostNetwork, this port is open on all nodes!
@@ -141,3 +144,9 @@ spec:
           hostPath:
             path: /dev
             type: Directory
+        - name: trusted-ca-bundle
+          configMap:
+            name: vsphere-csi-driver-trusted-ca-bundle
+            items:
+              - key: ca-bundle.crt
+                path: tls-ca-bundle.pem

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -87,6 +87,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 			"node_sa.yaml",
 			"csidriver.yaml",
 			"service.yaml",
+			"ca_configmap.yaml",
 			"rbac/attacher_role.yaml",
 			"rbac/attacher_binding.yaml",
 			"rbac/controller_privileged_binding.yaml",


### PR DESCRIPTION
The CA bundle may contain certificate used to connect to vCenter

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1969719, however, this is about the CSI driver, not vsphere-problem-detector and thus may not be necessary to be backported.

/assign @gnufied 