### PR TITLE
Driver in the node deals with ConfigMaps now

### DIFF
--- a/assets/rbac/csi_driver_binding.yaml
+++ b/assets/rbac/csi_driver_binding.yaml
@@ -6,6 +6,9 @@ subjects:
   - kind: ServiceAccount
     name: vmware-vsphere-csi-driver-controller-sa
     namespace: openshift-cluster-csi-drivers
+  - kind: ServiceAccount
+    name: vmware-vsphere-csi-driver-node-sa
+    namespace: openshift-cluster-csi-drivers
 roleRef:
   kind: ClusterRole
   name: vmware-vsphere-csi-driver-role


### PR DESCRIPTION
This is seen at https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_vmware-vsphere-csi-driver/12/pull-ci-openshift-vmware-vsphere-csi-driver-master-e2e-vsphere-csi/1417212289345392640

CC @openshift/storage
