### PR TITLE
Bug 1985847: Disable CSI migration and webhook deployment

### DIFF
--- a/assets/vsphere_features_config.yaml
+++ b/assets/vsphere_features_config.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  "csi-migration": "true" # csi-migration feature is only available for vSphere 7.0U1
+  "csi-migration": "false" # csi-migration feature is only available for vSphere 7.0U1
   "csi-auth-check": "true"
   "online-volume-extend": "true"
 kind: ConfigMap

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -104,12 +104,12 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 			"rbac/prometheus_role.yaml",
 			"rbac/prometheus_rolebinding.yaml",
 			// Static assets used by the webhook
-			"webhook/config.yaml",
-			"webhook/sa.yaml",
-			"webhook/service.yaml",
-			"webhook/configuration.yaml",
-			"webhook/rbac/role.yaml",
-			"webhook/rbac/rolebinding.yaml",
+			// "webhook/config.yaml",
+			// "webhook/sa.yaml",
+			// "webhook/service.yaml",
+			// "webhook/configuration.yaml",
+			// "webhook/rbac/role.yaml",
+			// "webhook/rbac/rolebinding.yaml",
 		},
 	).WithCSIConfigObserverController(
 		"VMwareVSphereDriverCSIConfigObserverController",
@@ -182,21 +182,21 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		controllerConfig.EventRecorder,
 	)
 
-	webhookBytes, err := assets.ReadFile("webhook/deployment.yaml")
-	if err != nil {
-		return err
-	}
-	webhookController := deploymentcontroller.NewDeploymentController(
-		"VMwareVSphereDriverWebhookController",
-		webhookBytes,
-		controllerConfig.EventRecorder,
-		operatorClient,
-		kubeClient,
-		kubeInformersForNamespaces.InformersFor(defaultNamespace).Apps().V1().Deployments(),
-		nil, // optionalInformers
-		nil, // optionalManifestHooks
-		WithSyncerImageHook("vsphere-webhook"),
-	)
+	// webhookBytes, err := assets.ReadFile("webhook/deployment.yaml")
+	// if err != nil {
+	// 	return err
+	// }
+	// webhookController := deploymentcontroller.NewDeploymentController(
+	// 	"VMwareVSphereDriverWebhookController",
+	// 	webhookBytes,
+	// 	controllerConfig.EventRecorder,
+	// 	operatorClient,
+	// 	kubeClient,
+	// 	kubeInformersForNamespaces.InformersFor(defaultNamespace).Apps().V1().Deployments(),
+	// 	nil, // optionalInformers
+	// 	nil, // optionalManifestHooks
+	// 	WithSyncerImageHook("vsphere-webhook"),
+	// )
 
 	klog.Info("Starting the informers")
 	go kubeInformersForNamespaces.Start(ctx.Done())
@@ -209,8 +209,8 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 	klog.Info("Starting storageclasscontroller")
 	go storageClassController.Run(ctx, 1)
 
-	klog.Info("Starting webhookcontroller")
-	go webhookController.Run(ctx, 1)
+	// klog.Info("Starting webhookcontroller")
+	// go webhookController.Run(ctx, 1)
 
 	klog.Info("Starting controllerset")
 	go csiControllerSet.Run(ctx, 1)


### PR DESCRIPTION
Since the driver is creating a bunch of v1beta1 CRDs, and that API is gone in OCP 4.9, we're disabling the deployment of the webhook and the CSI migration feature in the CSI driver. This should prevent the creation of CRD by the driver/syncer.

We'll revisit those once the upstream CRDs have been migrated to v1.

CC @openshift/storage
