### PR TITLE
[wip] substitute datastore path at job runtime based on hosting cloud

### DIFF
--- a/test/e2e/storageclass-ci.yaml
+++ b/test/e2e/storageclass-ci.yaml
@@ -8,7 +8,7 @@ metadata:
   name: csi-ci
 parameters:
   # Datastore URL in OCP CI
-  datastoreurl: ds:///vmfs/volumes/vsan:86c7dbc3da924855-b20d5cd1f4eec976/
+  datastoreurl: ${VSPHERE_DATASTORE_PATH}
 provisioner: csi.vsphere.vmware.com
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
IBM Cloud is enabled as a possible platform where CI jobs can run.  At present, the datastore URL is hard coded in the storageclass.  The intent of this PR is to templatize the storageclass and allow the datastore path to be provided at job runtime.  Associated PR https://github.com/openshift/release/pull/21819 