### PR TITLE
Bug 2009859: Close connection to vCenter API

### DIFF
--- a/pkg/operator/storageclasscontroller/storageclasscontroller.go
+++ b/pkg/operator/storageclasscontroller/storageclasscontroller.go
@@ -160,11 +160,17 @@ func (c *StorageClassController) syncStoragePolicy(ctx context.Context) (string,
 	if err != nil {
 		return "", fmt.Errorf("failed to get credentials: %v", err)
 	}
-	apiClient, err := newVCenterAPI(ctx, cfg, username, password, infra)
 
+	apiClient, err := newVCenterAPI(ctx, cfg, username, password, infra)
 	if err != nil {
 		return "", fmt.Errorf("error connecting to vcenter API: %v", err)
 	}
+	defer func() {
+		err := apiClient.close(ctx)
+		if err != nil {
+			klog.Errorf("error closing connection to vCenter API: %v", err)
+		}
+	}()
 
 	// we expect all API calls to finish within apiTimeout or else operator might be stuck
 	tctx, cancel := context.WithTimeout(ctx, apiTimeout)


### PR DESCRIPTION
Currently, every time the operator syncs a new session is established.

This patch changes the current behavior by closing the session after it was used.

This should help improving the current situation, however we also need to investigate the upstream CSI driver which apparently is leaking sessions as well.

CC @openshift/storage 