### PR TITLE
[release-4.8] Bug 2021620: Close connection to vCenter API

### DIFF
--- a/pkg/operator/storageclasscontroller/storageclasscontroller.go
+++ b/pkg/operator/storageclasscontroller/storageclasscontroller.go
@@ -171,6 +171,14 @@ func (c *StorageClassController) getDatastoreURL(ctx context.Context) (string, e
 		client: client,
 		config: cfg,
 	}
+
+	defer func() {
+		err := client.Logout(ctx)
+		if err != nil {
+			klog.Errorf("error closing connection to vCenter API: %v", err)
+		}
+	}()
+
 	ds, err := c.getDefaultDatastore(ctx, conn)
 	if err != nil {
 		return "", fmt.Errorf("error getting default datastore: %v", err)


### PR DESCRIPTION
The intention of this PR is to backport a fix to close stale connections which was implemented in #50 and #47 to 4.8.  There are structural differences in pkg/operator/storageclasscontroller/vmware.go which prevent a cherrypick and as such this PR was created.  As is done in prior PRs on this issue, logout is called on the vim25.Client instance which results in the session being logged out and idle connections being closed.