### PR TITLE
readme: minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ oc apply -f https://raw.githubusercontent.com/openshift/cluster-storage-operator
 make
 
 # Set the environment variables
-export DRIVER_IMAGE=quay.io/openshift/origin-vmware-vsphere-csi-driver:latest
+export DRIVER_IMAGE=quay.io/openshift/origin-vsphere-csi-driver:latest
 export PROVISIONER_IMAGE=quay.io/openshift/origin-csi-external-provisioner:latest
 export ATTACHER_IMAGE=quay.io/openshift/origin-csi-external-attacher:latest
 export RESIZER_IMAGE=quay.io/openshift/origin-csi-external-resizer:latest
@@ -35,6 +35,7 @@ export SNAPSHOTTER_IMAGE=quay.io/openshift/origin-csi-external-snapshotter:lates
 export NODE_DRIVER_REGISTRAR_IMAGE=quay.io/openshift/origin-csi-node-driver-registrar:latest
 export LIVENESS_PROBE_IMAGE=quay.io/openshift/origin-csi-livenessprobe:latest
 export KUBE_RBAC_PROXY_IMAGE=quay.io/openshift/origin-kube-rbac-proxy:latest
+export VMWARE_VSPHERE_SYNCER_IMAGE=quay.io/openshift/origin-vsphere-csi-driver-syncer
 
 # Run the operator via CLI
 ./vmware-vsphere-csi-driver-operator start --kubeconfig $MY_KUBECONFIG --namespace openshift-cluster-csi-drivers


### PR DESCRIPTION
Environment variable with syncer image name was missing. If this var is not configured the operator will fail to start.

Also the driver image has a different name:

```
$ docker pull quay.io/openshift/origin-vmware-vsphere-csi-driver:latest
Error response from daemon: unauthorized: access to the requested resource is not authorized
$ docker pull quay.io/openshift/origin-vsphere-csi-driver:latest
latest: Pulling from openshift/origin-vsphere-csi-driver
Digest: sha256:1a98c1afaae87b828323400c331ad1de7f03d56416cc5196aeebd95595eedf31
Status: Image is up to date for quay.io/openshift/origin-vsphere-csi-driver:latest
quay.io/openshift/origin-vsphere-csi-driver:latest
```
