### PR TITLE
Bug 1870489: Verify that tests correctly handle not rounding to the GiB

### DIFF
--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -11,7 +11,7 @@ DriverInfo:
   SupportedMountOption:
     dirsync:
   SupportedSizeRange:
-    Min: 1Gi
+    Min: 100Mi
     Max: 64Ti
   Capabilities:
     persistence: true


### PR DESCRIPTION
Verify that [PR #199](https://github.com/kubernetes-csi/external-provisioner/issues/199) addresses [Issue #94128](https://github.com/kubernetes/kubernetes/issues/94128) by changing the vSphere tests to use a non GiB aligned minimum value. The vSphere CSI driver is used because it is one of the few drivers that doesn't round to the GiB.