### PR TITLE
Bug 2040880: Degrade the OCP cluster if driver is found

### DIFF
--- a/pkg/operator/vspherecontroller/vspherecontroller_test.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller_test.go
@@ -161,6 +161,16 @@ func TestSync(t *testing.T) {
 			operandStarted: false,
 		},
 		{
+			name:                   "when we can't connect to vcenter but CSI driver was installed previously, degrade cluster",
+			clusterCSIDriverObject: makeFakeDriverInstance(),
+			vcenterVersion:         "7.0.2",
+			initialObjects:         []runtime.Object{getConfigMap(), getSecret(), getCSIDriver(true /*withOCPAnnotation*/)},
+			configObjects:          runtime.Object(getInfraObject()),
+			failVCenterConnection:  true,
+			expectError:            fmt.Errorf("can't talk to vcenter"),
+			operandStarted:         true,
+		},
+		{
 			name:                   "when vcenter version is older, block upgrades",
 			clusterCSIDriverObject: makeFakeDriverInstance(),
 			initialObjects:         []runtime.Object{getConfigMap(), getSecret()},


### PR DESCRIPTION
Previously we did not degrade or mark cluster as unpgradeable when we can't connect to vcenter.

This PR changes that behaviour and *always* degrades the cluster if we previously installed the CSI driver and one or more of CSI driver pre-requisties is unsatisfied. This is necessary because CSI driver will be crash looping or being non-functional anyway when this happens. 

xref https://bugzilla.redhat.com/show_bug.cgi?id=2040880
