### PR TITLE
add storageclass controller tests

### DIFF
--- a/pkg/operator/storageclasscontroller/storageclasscontroller_test.go
+++ b/pkg/operator/storageclasscontroller/storageclasscontroller_test.go
@@ -1,0 +1,179 @@
+package storageclasscontroller
+
+import (
+	"context"
+	"fmt"
+	v1 "github.com/openshift/api/config/v1"
+	opv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/testlib"
+	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/utils"
+	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/vclib"
+	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/vspherecontroller/checks"
+	"k8s.io/apimachinery/pkg/runtime"
+	"testing"
+)
+
+const (
+	testScControllerName      = "test-sc-controller"
+	testScControllerNamespace = "test-sc-namespace"
+)
+
+type fakeStoragePolicyAPI struct {
+	vCenterInterface
+	ret string
+	err error
+}
+
+func (v *fakeStoragePolicyAPI) createStoragePolicy(ctx context.Context) (string, error) {
+	return v.ret, v.err
+}
+
+func newFakeStoragePolicyAPISuccess(ctx context.Context, connection *vclib.VSphereConnection, infra *v1.Infrastructure) vCenterInterface {
+	fakeStoragePolicyAPI := &fakeStoragePolicyAPI{ret: "fake-return-value"}
+	return fakeStoragePolicyAPI
+}
+
+func newFakeStoragePolicyAPIFailure(ctx context.Context, connection *vclib.VSphereConnection, infra *v1.Infrastructure) vCenterInterface {
+	fakeStoragePolicyAPI := &fakeStoragePolicyAPI{ret: "fake-return-value", err: fmt.Errorf("fake-error")}
+	return fakeStoragePolicyAPI
+}
+
+func newStorageClassController(apiClients *utils.APIClient, storageclassfile string, storagePolicyAPIfailing bool) *StorageClassController {
+	rc := events.NewInMemoryRecorder(testScControllerName)
+	scBytes, err := testlib.ReadFile(storageclassfile)
+	if err != nil {
+		panic("unable to read storageclass file")
+	}
+
+	spFunc := newFakeStoragePolicyAPISuccess
+	if storagePolicyAPIfailing {
+		spFunc = newFakeStoragePolicyAPIFailure
+	}
+
+	c := &StorageClassController{
+		name:                 testScControllerName,
+		targetNamespace:      testScControllerNamespace,
+		manifest:             scBytes,
+		kubeClient:           apiClients.KubeClient,
+		operatorClient:       apiClients.OperatorClient,
+		recorder:             rc,
+		makeStoragePolicyAPI: spFunc,
+	}
+
+	return c
+}
+
+func getCheckAPIDependency(apiClients *utils.APIClient) checks.KubeAPIInterface {
+	kubeInformers := apiClients.KubeInformers
+
+	csiDriverLister := kubeInformers.InformersFor("").Storage().V1().CSIDrivers().Lister()
+	csiNodeLister := kubeInformers.InformersFor("").Storage().V1().CSINodes().Lister()
+	nodeLister := apiClients.NodeInformer.Lister()
+	i := &checks.KubeAPIInterfaceImpl{
+		Infrastructure:  testlib.GetInfraObject(),
+		CSINodeLister:   csiNodeLister,
+		CSIDriverLister: csiDriverLister,
+		NodeLister:      nodeLister,
+	}
+
+	return i
+}
+
+func assertPanic(t *testing.T) {
+	if r := recover(); r == nil {
+		t.Errorf("Test should have panicked but did not.")
+	}
+}
+
+func TestSync(t *testing.T) {
+	tests := []struct {
+		name                   string
+		clusterCSIDriverObject *testlib.FakeDriverInstance
+		initialObjects         []runtime.Object
+		configObjects          runtime.Object
+		storageClass           string
+		expectError            error
+		expectedConditions     []opv1.OperatorCondition
+		scConstructor          interface{}
+		StoragePolicyAPIfails  bool
+		shouldPanic            bool
+	}{
+		{
+			name:                   "sync succeeds with valid storage class",
+			clusterCSIDriverObject: testlib.MakeFakeDriverInstance(),
+			initialObjects:         []runtime.Object{testlib.GetConfigMap(), testlib.GetSecret()},
+			configObjects:          runtime.Object(testlib.GetInfraObject()),
+			storageClass:           "storageclass1.yaml",
+			expectedConditions: []opv1.OperatorCondition{
+				{
+					Type:   testScControllerName + opv1.OperatorStatusTypeAvailable,
+					Status: opv1.ConditionTrue,
+				},
+				{
+					Type:   testScControllerName + opv1.OperatorStatusTypeDegraded,
+					Status: opv1.ConditionFalse,
+				},
+			},
+		},
+		{
+			name:                   "sync does not degrade on storage policy api error",
+			clusterCSIDriverObject: testlib.MakeFakeDriverInstance(),
+			initialObjects:         []runtime.Object{testlib.GetConfigMap(), testlib.GetSecret()},
+			configObjects:          runtime.Object(testlib.GetInfraObject()),
+			storageClass:           "storageclass1.yaml",
+			StoragePolicyAPIfails:  true,
+			expectedConditions: []opv1.OperatorCondition{
+				{
+					Type:   testScControllerName + opv1.OperatorStatusTypeAvailable,
+					Status: opv1.ConditionTrue,
+				},
+				{
+					Type:   testScControllerName + opv1.OperatorStatusTypeDegraded,
+					Status: opv1.ConditionFalse,
+				},
+			},
+		},
+		{
+			name:                   "sync panics with invalid storage class object",
+			clusterCSIDriverObject: testlib.MakeFakeDriverInstance(),
+			initialObjects:         []runtime.Object{testlib.GetConfigMap(), testlib.GetSecret()},
+			configObjects:          runtime.Object(testlib.GetInfraObject()),
+			storageClass:           "storageclass2.yaml",
+			shouldPanic:            true,
+		},
+	}
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			commonApiClient := testlib.NewFakeClients(test.initialObjects, test.clusterCSIDriverObject, test.configObjects)
+
+			apiDeps := getCheckAPIDependency(commonApiClient)
+			var conn *vclib.VSphereConnection
+			scController := newStorageClassController(commonApiClient, test.storageClass, test.StoragePolicyAPIfails)
+
+			if test.shouldPanic {
+				defer assertPanic(t)
+			}
+			// err will be nil on even on failure, need to check conditions instead
+			err := scController.Sync(context.TODO(), conn, apiDeps)
+
+			_, status, _, err := scController.operatorClient.GetOperatorState()
+			if err != nil {
+				t.Errorf("failed to get operator state: %+v", err)
+			}
+
+			for i := range test.expectedConditions {
+				expectedCondition := test.expectedConditions[i]
+				matchingCondition := testlib.GetMatchingCondition(status.Conditions, expectedCondition.Type)
+				if matchingCondition == nil {
+					t.Fatalf("found no matching condition for: %s", expectedCondition.Type)
+				}
+				if matchingCondition.Status != expectedCondition.Status {
+					t.Fatalf("for condition %s: expected status: %v, got: %v", expectedCondition.Type, expectedCondition.Status, matchingCondition.Status)
+				}
+			}
+
+		})
+	}
+}

--- a/pkg/operator/testlib/storageclass1.yaml
+++ b/pkg/operator/testlib/storageclass1.yaml
@@ -1,0 +1,10 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: thin-csi
+provisioner: csi.vsphere.vmware.com
+parameters:
+  StoragePolicyName: "fake-storage-policy"
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+reclaimPolicy: Delete

--- a/pkg/operator/testlib/storageclass2.yaml
+++ b/pkg/operator/testlib/storageclass2.yaml
@@ -1,0 +1,10 @@
+kind: StorageClass
+apiVersion: invalid-value
+metadata:
+  name: thin-csi-renamed
+provisioner: csi.vsphere.vmware.com
+parameters:
+  StoragePolicyName: "fake-storage-policy"
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+reclaimPolicy: Delete

--- a/pkg/operator/testlib/testlib.go
+++ b/pkg/operator/testlib/testlib.go
@@ -1,6 +1,7 @@
 package testlib
 
 import (
+	"embed"
 	"fmt"
 	ocpv1 "github.com/openshift/api/config/v1"
 	opv1 "github.com/openshift/api/operator/v1"
@@ -17,6 +18,9 @@ import (
 	fakecore "k8s.io/client-go/kubernetes/fake"
 )
 
+//go:embed *.yaml
+var f embed.FS
+
 const (
 	cloudConfigNamespace = "openshift-config"
 	infraGlobalName      = "cluster"
@@ -29,6 +33,11 @@ type FakeDriverInstance struct {
 	metav1.ObjectMeta
 	Spec   opv1.OperatorSpec
 	Status opv1.OperatorStatus
+}
+
+// ReadFile reads and returns the content of the named file.
+func ReadFile(name string) ([]byte, error) {
+	return f.ReadFile(name)
 }
 
 func WaitForSync(clients *utils.APIClient, stopCh <-chan struct{}) {

--- a/pkg/operator/testlib/testlib.go
+++ b/pkg/operator/testlib/testlib.go
@@ -1,0 +1,229 @@
+package testlib
+
+import (
+	"fmt"
+	ocpv1 "github.com/openshift/api/config/v1"
+	opv1 "github.com/openshift/api/operator/v1"
+	fakeconfig "github.com/openshift/client-go/config/clientset/versioned/fake"
+	cfginformers "github.com/openshift/client-go/config/informers/externalversions"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/utils"
+	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/vspherecontroller/checks"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	fakecore "k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	cloudConfigNamespace = "openshift-config"
+	infraGlobalName      = "cluster"
+	secretName           = "vmware-vsphere-cloud-credentials"
+	defaultNamespace     = "openshift-cluster-csi-drivers"
+)
+
+// fakeInstance is a fake CSI driver instance that also fullfils the OperatorClient interface
+type FakeDriverInstance struct {
+	metav1.ObjectMeta
+	Spec   opv1.OperatorSpec
+	Status opv1.OperatorStatus
+}
+
+func WaitForSync(clients *utils.APIClient, stopCh <-chan struct{}) {
+	clients.KubeInformers.InformersFor(defaultNamespace).WaitForCacheSync(stopCh)
+	clients.KubeInformers.InformersFor("").WaitForCacheSync(stopCh)
+	clients.KubeInformers.InformersFor(cloudConfigNamespace).WaitForCacheSync(stopCh)
+	clients.ConfigInformers.WaitForCacheSync(stopCh)
+}
+
+func StartFakeInformer(clients *utils.APIClient, stopCh <-chan struct{}) {
+	for _, informer := range []interface {
+		Start(stopCh <-chan struct{})
+	}{
+		clients.KubeInformers,
+		clients.ConfigInformers,
+	} {
+		informer.Start(stopCh)
+	}
+}
+
+func NewFakeClients(coreObjects []runtime.Object, operatorObject *FakeDriverInstance, configObject runtime.Object) *utils.APIClient {
+	dynamicClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	kubeClient := fakecore.NewSimpleClientset(coreObjects...)
+	kubeInformers := v1helpers.NewKubeInformersForNamespaces(kubeClient, defaultNamespace, cloudConfigNamespace, "")
+	nodeInformer := kubeInformers.InformersFor("").Core().V1().Nodes()
+	secretInformer := kubeInformers.InformersFor(defaultNamespace).Core().V1().Secrets()
+
+	apiClient := &utils.APIClient{}
+	apiClient.KubeClient = kubeClient
+	apiClient.KubeInformers = kubeInformers
+	apiClient.NodeInformer = nodeInformer
+	apiClient.SecretInformer = secretInformer
+	apiClient.DynamicClient = dynamicClient
+
+	operatorClient := v1helpers.NewFakeOperatorClientWithObjectMeta(&operatorObject.ObjectMeta, &operatorObject.Spec, &operatorObject.Status, nil)
+	apiClient.OperatorClient = operatorClient
+
+	configClient := fakeconfig.NewSimpleClientset(configObject)
+	configInformerFactory := cfginformers.NewSharedInformerFactory(configClient, 0)
+	configInformer := configInformerFactory.Config().V1().Infrastructures().Informer()
+	configInformer.GetIndexer().Add(configObject)
+
+	apiClient.ConfigClientSet = configClient
+	apiClient.ConfigInformers = configInformerFactory
+	return apiClient
+}
+
+func AddInitialObjects(objects []runtime.Object, clients *utils.APIClient) error {
+	for _, obj := range objects {
+		switch obj.(type) {
+		case *v1.ConfigMap:
+			configMapInformer := clients.KubeInformers.InformersFor(cloudConfigNamespace).Core().V1().ConfigMaps().Informer()
+			configMapInformer.GetStore().Add(obj)
+		case *v1.Secret:
+			secretInformer := clients.SecretInformer.Informer()
+			secretInformer.GetStore().Add(obj)
+		case *storagev1.CSIDriver:
+			csiDriverInformer := clients.KubeInformers.InformersFor("").Storage().V1().CSIDrivers().Informer()
+			csiDriverInformer.GetStore().Add(obj)
+		case *storagev1.CSINode:
+			csiNodeInformer := clients.KubeInformers.InformersFor("").Storage().V1().CSINodes().Informer()
+			csiNodeInformer.GetStore().Add(obj)
+		case *v1.Node:
+			nodeInformer := clients.NodeInformer
+			nodeInformer.Informer().GetStore().Add(obj)
+		default:
+			return fmt.Errorf("Unknown initalObject type: %+v", obj)
+		}
+	}
+	return nil
+}
+
+func GetMatchingCondition(status []opv1.OperatorCondition, conditionType string) *opv1.OperatorCondition {
+	for _, condition := range status {
+		if condition.Type == conditionType {
+			return &condition
+		}
+	}
+	return nil
+}
+
+type driverModifier func(*FakeDriverInstance) *FakeDriverInstance
+
+func MakeFakeDriverInstance(modifiers ...driverModifier) *FakeDriverInstance {
+	instance := &FakeDriverInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "cluster",
+			Generation: 0,
+		},
+		Spec: opv1.OperatorSpec{
+			ManagementState: opv1.Managed,
+		},
+		Status: opv1.OperatorStatus{},
+	}
+	for _, modifier := range modifiers {
+		instance = modifier(instance)
+	}
+	return instance
+}
+
+func GetCSIDriver(withOCPAnnotation bool) *storagev1.CSIDriver {
+	driver := &storagev1.CSIDriver{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: utils.VSphereDriverName,
+		},
+		Spec: storagev1.CSIDriverSpec{},
+	}
+	if withOCPAnnotation {
+		driver.Annotations = map[string]string{
+			utils.OpenshiftCSIDriverAnnotationKey: "true",
+		}
+	}
+	return driver
+}
+
+func GetCSINode() *storagev1.CSINode {
+	return &storagev1.CSINode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-abcd",
+		},
+		Spec: storagev1.CSINodeSpec{
+			Drivers: []storagev1.CSINodeDriver{
+				{
+					Name: utils.VSphereDriverName,
+				},
+			},
+		},
+	}
+}
+
+func GetInfraObject() *ocpv1.Infrastructure {
+	return &ocpv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: infraGlobalName,
+		},
+		Spec: ocpv1.InfrastructureSpec{
+			CloudConfig: ocpv1.ConfigMapFileReference{
+				Name: "cloud-provider-config",
+				Key:  "config",
+			},
+			PlatformSpec: ocpv1.PlatformSpec{
+				Type: ocpv1.VSpherePlatformType,
+			},
+		},
+		Status: ocpv1.InfrastructureStatus{
+			InfrastructureName: "vsphere",
+			PlatformStatus: &ocpv1.PlatformStatus{
+				Type: ocpv1.VSpherePlatformType,
+			},
+		},
+	}
+}
+
+func GetConfigMap() *v1.ConfigMap {
+	return &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cloud-provider-config",
+			Namespace: cloudConfigNamespace,
+		},
+		Data: map[string]string{
+			"config": `
+[Global]
+secret-name = "vsphere-creds"
+secret-namespace = "kube-system"
+insecure-flag = "1"
+
+[Workspace]
+server = "localhost"
+datacenter = "DC0"
+default-datastore = "LocalDS_0"
+folder = "/DC0/vm"
+
+[VirtualCenter "dc0"]
+datacenters = "DC0"
+`,
+		},
+	}
+}
+
+func GetSecret() *v1.Secret {
+	return &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: defaultNamespace,
+		},
+		Data: map[string][]byte{
+			"localhost.password": []byte("vsphere-user"),
+			"localhost.username": []byte("vsphere-password"),
+		},
+	}
+}
+
+func GetTestClusterResult(statusType checks.CheckStatusType) checks.ClusterCheckResult {
+	return checks.ClusterCheckResult{
+		CheckError:  fmt.Errorf("some error"),
+		CheckStatus: statusType,
+	}
+}

--- a/pkg/operator/vspherecontroller/vspherecontroller_test.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller_test.go
@@ -6,79 +6,20 @@ import (
 	"testing"
 	"time"
 
-	ocpv1 "github.com/openshift/api/config/v1"
 	opv1 "github.com/openshift/api/operator/v1"
-	fakeconfig "github.com/openshift/client-go/config/clientset/versioned/fake"
-	cfginformers "github.com/openshift/client-go/config/informers/externalversions"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
-	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/testlib"
 	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/utils"
 	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/vclib"
 	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/vspherecontroller/checks"
 	v1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	dynamicfake "k8s.io/client-go/dynamic/fake"
-	fakecore "k8s.io/client-go/kubernetes/fake"
 )
 
 const (
 	testControllerName = "VMwareVSphereController"
 )
-
-// fakeInstance is a fake CSI driver instance that also fullfils the OperatorClient interface
-type fakeDriverInstance struct {
-	metav1.ObjectMeta
-	Spec   opv1.OperatorSpec
-	Status opv1.OperatorStatus
-}
-
-func waitForSync(clients *utils.APIClient, stopCh <-chan struct{}) {
-	clients.KubeInformers.InformersFor(defaultNamespace).WaitForCacheSync(stopCh)
-	clients.KubeInformers.InformersFor("").WaitForCacheSync(stopCh)
-	clients.KubeInformers.InformersFor(cloudConfigNamespace).WaitForCacheSync(stopCh)
-	clients.ConfigInformers.WaitForCacheSync(stopCh)
-}
-
-func startFakeInformer(clients *utils.APIClient, stopCh <-chan struct{}) {
-	for _, informer := range []interface {
-		Start(stopCh <-chan struct{})
-	}{
-		clients.KubeInformers,
-		clients.ConfigInformers,
-	} {
-		informer.Start(stopCh)
-	}
-}
-
-func newFakeClients(coreObjects []runtime.Object, operatorObject *fakeDriverInstance, configObject runtime.Object) *utils.APIClient {
-	dynamicClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
-	kubeClient := fakecore.NewSimpleClientset(coreObjects...)
-	kubeInformers := v1helpers.NewKubeInformersForNamespaces(kubeClient, defaultNamespace, cloudConfigNamespace, "")
-	nodeInformer := kubeInformers.InformersFor("").Core().V1().Nodes()
-	secretInformer := kubeInformers.InformersFor(defaultNamespace).Core().V1().Secrets()
-
-	apiClient := &utils.APIClient{}
-	apiClient.KubeClient = kubeClient
-	apiClient.KubeInformers = kubeInformers
-	apiClient.NodeInformer = nodeInformer
-	apiClient.SecretInformer = secretInformer
-	apiClient.DynamicClient = dynamicClient
-
-	operatorClient := v1helpers.NewFakeOperatorClientWithObjectMeta(&operatorObject.ObjectMeta, &operatorObject.Spec, &operatorObject.Status, nil)
-	apiClient.OperatorClient = operatorClient
-
-	configClient := fakeconfig.NewSimpleClientset(configObject)
-	configInformerFactory := cfginformers.NewSharedInformerFactory(configClient, 0)
-	configInformer := configInformerFactory.Config().V1().Infrastructures().Informer()
-	configInformer.GetIndexer().Add(configObject)
-
-	apiClient.ConfigClientSet = configClient
-	apiClient.ConfigInformers = configInformerFactory
-	return apiClient
-}
 
 func newVsphereController(apiClients *utils.APIClient) *VSphereController {
 	kubeInformers := apiClients.KubeInformers
@@ -115,7 +56,7 @@ func newVsphereController(apiClients *utils.APIClient) *VSphereController {
 func TestSync(t *testing.T) {
 	tests := []struct {
 		name                         string
-		clusterCSIDriverObject       *fakeDriverInstance
+		clusterCSIDriverObject       *testlib.FakeDriverInstance
 		initialObjects               []runtime.Object
 		configObjects                runtime.Object
 		vcenterVersion               string
@@ -128,11 +69,11 @@ func TestSync(t *testing.T) {
 	}{
 		{
 			name:                         "when all configuration is right",
-			clusterCSIDriverObject:       makeFakeDriverInstance(),
+			clusterCSIDriverObject:       testlib.MakeFakeDriverInstance(),
 			vcenterVersion:               "7.0.2",
 			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
-			initialObjects:               []runtime.Object{getConfigMap(), getSecret()},
-			configObjects:                runtime.Object(getInfraObject()),
+			initialObjects:               []runtime.Object{testlib.GetConfigMap(), testlib.GetSecret()},
+			configObjects:                runtime.Object(testlib.GetInfraObject()),
 			expectedConditions: []opv1.OperatorCondition{
 				{
 					Type:   testControllerName + opv1.OperatorStatusTypeAvailable,
@@ -147,11 +88,11 @@ func TestSync(t *testing.T) {
 		},
 		{
 			name:                         "when we can't connect to vcenter",
-			clusterCSIDriverObject:       makeFakeDriverInstance(),
+			clusterCSIDriverObject:       testlib.MakeFakeDriverInstance(),
 			vcenterVersion:               "7.0.2",
 			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
-			initialObjects:               []runtime.Object{getConfigMap(), getSecret()},
-			configObjects:                runtime.Object(getInfraObject()),
+			initialObjects:               []runtime.Object{testlib.GetConfigMap(), testlib.GetSecret()},
+			configObjects:                runtime.Object(testlib.GetInfraObject()),
 			failVCenterConnection:        true,
 			expectedConditions: []opv1.OperatorCondition{
 				{
@@ -167,21 +108,21 @@ func TestSync(t *testing.T) {
 		},
 		{
 			name:                         "when we can't connect to vcenter but CSI driver was installed previously, degrade cluster",
-			clusterCSIDriverObject:       makeFakeDriverInstance(),
+			clusterCSIDriverObject:       testlib.MakeFakeDriverInstance(),
 			vcenterVersion:               "7.0.2",
 			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
-			initialObjects:               []runtime.Object{getConfigMap(), getSecret(), getCSIDriver(true /*withOCPAnnotation*/)},
-			configObjects:                runtime.Object(getInfraObject()),
+			initialObjects:               []runtime.Object{testlib.GetConfigMap(), testlib.GetSecret(), testlib.GetCSIDriver(true /*withOCPAnnotation*/)},
+			configObjects:                runtime.Object(testlib.GetInfraObject()),
 			failVCenterConnection:        true,
 			expectError:                  fmt.Errorf("can't talk to vcenter"),
 			operandStarted:               true,
 		},
 		{
 			name:                         "when vcenter version is older, block upgrades",
-			clusterCSIDriverObject:       makeFakeDriverInstance(),
+			clusterCSIDriverObject:       testlib.MakeFakeDriverInstance(),
 			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
-			initialObjects:               []runtime.Object{getConfigMap(), getSecret()},
-			configObjects:                runtime.Object(getInfraObject()),
+			initialObjects:               []runtime.Object{testlib.GetConfigMap(), testlib.GetSecret()},
+			configObjects:                runtime.Object(testlib.GetInfraObject()),
 			expectedConditions: []opv1.OperatorCondition{
 				{
 					Type:   testControllerName + opv1.OperatorStatusTypeAvailable,
@@ -196,20 +137,20 @@ func TestSync(t *testing.T) {
 		},
 		{
 			name:                         "when vcenter version is older but csi driver exists, degrade cluster",
-			clusterCSIDriverObject:       makeFakeDriverInstance(),
+			clusterCSIDriverObject:       testlib.MakeFakeDriverInstance(),
 			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
-			initialObjects:               []runtime.Object{getConfigMap(), getSecret(), getCSIDriver(true)},
-			configObjects:                runtime.Object(getInfraObject()),
+			initialObjects:               []runtime.Object{testlib.GetConfigMap(), testlib.GetSecret(), testlib.GetCSIDriver(true)},
+			configObjects:                runtime.Object(testlib.GetInfraObject()),
 			expectError:                  fmt.Errorf("found older vcenter version, expected is 6.7.3"),
 			operandStarted:               true,
 		},
 		{
 			name:                         "when all configuration is right, but an existing upstream CSI driver exists",
-			clusterCSIDriverObject:       makeFakeDriverInstance(),
+			clusterCSIDriverObject:       testlib.MakeFakeDriverInstance(),
 			vcenterVersion:               "7.0.2",
 			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
-			initialObjects:               []runtime.Object{getConfigMap(), getSecret(), getCSIDriver(false)},
-			configObjects:                runtime.Object(getInfraObject()),
+			initialObjects:               []runtime.Object{testlib.GetConfigMap(), testlib.GetSecret(), testlib.GetCSIDriver(false)},
+			configObjects:                runtime.Object(testlib.GetInfraObject()),
 			expectedConditions: []opv1.OperatorCondition{
 				{
 					Type:   testControllerName + opv1.OperatorStatusTypeAvailable,
@@ -224,11 +165,11 @@ func TestSync(t *testing.T) {
 		},
 		{
 			name:                         "when all configuration is right, but an existing upstream CSI node object exists",
-			clusterCSIDriverObject:       makeFakeDriverInstance(),
+			clusterCSIDriverObject:       testlib.MakeFakeDriverInstance(),
 			vcenterVersion:               "7.0.2",
 			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
-			initialObjects:               []runtime.Object{getConfigMap(), getSecret(), getCSINode()},
-			configObjects:                runtime.Object(getInfraObject()),
+			initialObjects:               []runtime.Object{testlib.GetConfigMap(), testlib.GetSecret(), testlib.GetCSINode()},
+			configObjects:                runtime.Object(testlib.GetInfraObject()),
 			expectedConditions: []opv1.OperatorCondition{
 				{
 					Type:   testControllerName + opv1.OperatorStatusTypeAvailable,
@@ -243,12 +184,12 @@ func TestSync(t *testing.T) {
 		},
 		{
 			name:                         "when node hw-version was old first and got upgraded",
-			clusterCSIDriverObject:       makeFakeDriverInstance(),
-			initialObjects:               []runtime.Object{getConfigMap(), getSecret()},
+			clusterCSIDriverObject:       testlib.MakeFakeDriverInstance(),
+			initialObjects:               []runtime.Object{testlib.GetConfigMap(), testlib.GetSecret()},
 			vcenterVersion:               "7.0.2",
 			startingNodeHardwareVersions: []string{"vmx-13", "vmx-15"},
 			finalNodeHardwareVersions:    []string{"vmx-15", "vmx-15"},
-			configObjects:                runtime.Object(getInfraObject()),
+			configObjects:                runtime.Object(testlib.GetInfraObject()),
 			expectedConditions: []opv1.OperatorCondition{
 				{
 					Type:   testControllerName + opv1.OperatorStatusTypeAvailable,
@@ -271,16 +212,16 @@ func TestSync(t *testing.T) {
 				test.initialObjects = append(test.initialObjects, runtime.Object(node))
 			}
 
-			commonApiClient := newFakeClients(test.initialObjects, test.clusterCSIDriverObject, test.configObjects)
+			commonApiClient := testlib.NewFakeClients(test.initialObjects, test.clusterCSIDriverObject, test.configObjects)
 			stopCh := make(chan struct{})
 			defer close(stopCh)
 
-			go startFakeInformer(commonApiClient, stopCh)
-			if err := addInitialObjects(test.initialObjects, commonApiClient); err != nil {
+			go testlib.StartFakeInformer(commonApiClient, stopCh)
+			if err := testlib.AddInitialObjects(test.initialObjects, commonApiClient); err != nil {
 				t.Fatalf("error adding initial objects: %v", err)
 			}
 
-			waitForSync(commonApiClient, stopCh)
+			testlib.WaitForSync(commonApiClient, stopCh)
 
 			ctrl := newVsphereController(commonApiClient)
 
@@ -327,7 +268,7 @@ func TestSync(t *testing.T) {
 			}
 			for i := range test.expectedConditions {
 				expectedCondition := test.expectedConditions[i]
-				matchingCondition := getMatchingCondition(status.Conditions, expectedCondition.Type)
+				matchingCondition := testlib.GetMatchingCondition(status.Conditions, expectedCondition.Type)
 				if matchingCondition == nil {
 					t.Fatalf("found no matching condition for: %s", expectedCondition.Type)
 				}
@@ -392,15 +333,15 @@ func TestAddUpgradeableBlockCondition(t *testing.T) {
 
 	tests := []struct {
 		name              string
-		clusterCSIDriver  *fakeDriverInstance
+		clusterCSIDriver  *testlib.FakeDriverInstance
 		clusterResult     checks.ClusterCheckResult
 		expectedCondition opv1.OperatorCondition
 		conditionModified bool
 	}{
 		{
 			name:             "when no existing condition is found, should add condition",
-			clusterCSIDriver: makeFakeDriverInstance(),
-			clusterResult:    getTestClusterResult(checks.CheckStatusVSphereConnectionFailed),
+			clusterCSIDriver: testlib.MakeFakeDriverInstance(),
+			clusterResult:    testlib.GetTestClusterResult(checks.CheckStatusVSphereConnectionFailed),
 			expectedCondition: opv1.OperatorCondition{
 				Type:   conditionType,
 				Status: opv1.ConditionFalse,
@@ -410,7 +351,7 @@ func TestAddUpgradeableBlockCondition(t *testing.T) {
 		},
 		{
 			name: "when an existing condition is found, should not modify condition",
-			clusterCSIDriver: makeFakeDriverInstance(func(instance *fakeDriverInstance) *fakeDriverInstance {
+			clusterCSIDriver: testlib.MakeFakeDriverInstance(func(instance *testlib.FakeDriverInstance) *testlib.FakeDriverInstance {
 				instance.Status.Conditions = []opv1.OperatorCondition{
 					{
 						Type:   conditionType,
@@ -420,7 +361,7 @@ func TestAddUpgradeableBlockCondition(t *testing.T) {
 				}
 				return instance
 			}),
-			clusterResult: getTestClusterResult(checks.CheckStatusVSphereConnectionFailed),
+			clusterResult: testlib.GetTestClusterResult(checks.CheckStatusVSphereConnectionFailed),
 			expectedCondition: opv1.OperatorCondition{
 				Type:   conditionType,
 				Status: opv1.ConditionFalse,
@@ -430,7 +371,7 @@ func TestAddUpgradeableBlockCondition(t *testing.T) {
 		},
 		{
 			name: "when an existing condition is found not has different reason, should modify condition",
-			clusterCSIDriver: makeFakeDriverInstance(func(instance *fakeDriverInstance) *fakeDriverInstance {
+			clusterCSIDriver: testlib.MakeFakeDriverInstance(func(instance *testlib.FakeDriverInstance) *testlib.FakeDriverInstance {
 				instance.Status.Conditions = []opv1.OperatorCondition{
 					{
 						Type:   conditionType,
@@ -440,7 +381,7 @@ func TestAddUpgradeableBlockCondition(t *testing.T) {
 				}
 				return instance
 			}),
-			clusterResult: getTestClusterResult(checks.CheckStatusVSphereConnectionFailed),
+			clusterResult: testlib.GetTestClusterResult(checks.CheckStatusVSphereConnectionFailed),
 			expectedCondition: opv1.OperatorCondition{
 				Type:   conditionType,
 				Status: opv1.ConditionFalse,
@@ -453,16 +394,16 @@ func TestAddUpgradeableBlockCondition(t *testing.T) {
 	for i := range tests {
 		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {
-			commonApiClient := newFakeClients([]runtime.Object{}, test.clusterCSIDriver, getInfraObject())
+			commonApiClient := testlib.NewFakeClients([]runtime.Object{}, test.clusterCSIDriver, testlib.GetInfraObject())
 			stopCh := make(chan struct{})
 			defer close(stopCh)
 
-			go startFakeInformer(commonApiClient, stopCh)
-			if err := addInitialObjects([]runtime.Object{}, commonApiClient); err != nil {
+			go testlib.StartFakeInformer(commonApiClient, stopCh)
+			if err := testlib.AddInitialObjects([]runtime.Object{}, commonApiClient); err != nil {
 				t.Fatalf("error adding initial objects: %v", err)
 			}
 
-			waitForSync(commonApiClient, stopCh)
+			testlib.WaitForSync(commonApiClient, stopCh)
 
 			ctrl := newVsphereController(commonApiClient)
 			condition, modified := ctrl.addUpgradeableBlockCondition(test.clusterResult, controllerName, &test.clusterCSIDriver.Status, opv1.ConditionFalse)
@@ -476,157 +417,5 @@ func TestAddUpgradeableBlockCondition(t *testing.T) {
 			}
 		})
 
-	}
-}
-
-func addInitialObjects(objects []runtime.Object, clients *utils.APIClient) error {
-	for _, obj := range objects {
-		switch obj.(type) {
-		case *v1.ConfigMap:
-			configMapInformer := clients.KubeInformers.InformersFor(cloudConfigNamespace).Core().V1().ConfigMaps().Informer()
-			configMapInformer.GetStore().Add(obj)
-		case *v1.Secret:
-			secretInformer := clients.SecretInformer.Informer()
-			secretInformer.GetStore().Add(obj)
-		case *storagev1.CSIDriver:
-			csiDriverInformer := clients.KubeInformers.InformersFor("").Storage().V1().CSIDrivers().Informer()
-			csiDriverInformer.GetStore().Add(obj)
-		case *storagev1.CSINode:
-			csiNodeInformer := clients.KubeInformers.InformersFor("").Storage().V1().CSINodes().Informer()
-			csiNodeInformer.GetStore().Add(obj)
-		case *v1.Node:
-			nodeInformer := clients.NodeInformer
-			nodeInformer.Informer().GetStore().Add(obj)
-		default:
-			return fmt.Errorf("Unknown initalObject type: %+v", obj)
-		}
-	}
-	return nil
-}
-
-func getMatchingCondition(status []opv1.OperatorCondition, conditionType string) *opv1.OperatorCondition {
-	for _, condition := range status {
-		if condition.Type == conditionType {
-			return &condition
-		}
-	}
-	return nil
-}
-
-type driverModifier func(*fakeDriverInstance) *fakeDriverInstance
-
-func makeFakeDriverInstance(modifiers ...driverModifier) *fakeDriverInstance {
-	instance := &fakeDriverInstance{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "cluster",
-			Generation: 0,
-		},
-		Spec: opv1.OperatorSpec{
-			ManagementState: opv1.Managed,
-		},
-		Status: opv1.OperatorStatus{},
-	}
-	for _, modifier := range modifiers {
-		instance = modifier(instance)
-	}
-	return instance
-}
-
-func getCSIDriver(withOCPAnnotation bool) *storagev1.CSIDriver {
-	driver := &storagev1.CSIDriver{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: utils.VSphereDriverName,
-		},
-		Spec: storagev1.CSIDriverSpec{},
-	}
-	if withOCPAnnotation {
-		driver.Annotations = map[string]string{
-			utils.OpenshiftCSIDriverAnnotationKey: "true",
-		}
-	}
-	return driver
-}
-
-func getCSINode() *storagev1.CSINode {
-	return &storagev1.CSINode{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "node-abcd",
-		},
-		Spec: storagev1.CSINodeSpec{
-			Drivers: []storagev1.CSINodeDriver{
-				{
-					Name: utils.VSphereDriverName,
-				},
-			},
-		},
-	}
-}
-
-func getInfraObject() *ocpv1.Infrastructure {
-	return &ocpv1.Infrastructure{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: infraGlobalName,
-		},
-		Spec: ocpv1.InfrastructureSpec{
-			CloudConfig: ocpv1.ConfigMapFileReference{
-				Name: "cloud-provider-config",
-				Key:  "config",
-			},
-			PlatformSpec: ocpv1.PlatformSpec{
-				Type: ocpv1.VSpherePlatformType,
-			},
-		},
-		Status: ocpv1.InfrastructureStatus{
-			InfrastructureName: "vsphere",
-			PlatformStatus: &ocpv1.PlatformStatus{
-				Type: ocpv1.VSpherePlatformType,
-			},
-		},
-	}
-}
-
-func getConfigMap() *v1.ConfigMap {
-	return &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "cloud-provider-config",
-			Namespace: cloudConfigNamespace,
-		},
-		Data: map[string]string{
-			"config": `
-[Global]
-secret-name = "vsphere-creds"
-secret-namespace = "kube-system"
-insecure-flag = "1"
-
-[Workspace]
-server = "localhost"
-datacenter = "DC0"
-default-datastore = "LocalDS_0"
-folder = "/DC0/vm"
-
-[VirtualCenter "dc0"]
-datacenters = "DC0"
-`,
-		},
-	}
-}
-
-func getSecret() *v1.Secret {
-	return &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
-			Namespace: defaultNamespace,
-		},
-		Data: map[string][]byte{
-			"localhost.password": []byte("vsphere-user"),
-			"localhost.username": []byte("vsphere-password"),
-		},
-	}
-}
-
-func getTestClusterResult(statusType checks.CheckStatusType) checks.ClusterCheckResult {
-	return checks.ClusterCheckResult{
-		CheckError:  fmt.Errorf("some error"),
-		CheckStatus: statusType,
 	}
 }


### PR DESCRIPTION
Adding basic storage class controller tests as we were missing coverage in this area completely.

The intention is to have tests where we can mock storage policy API, and control it's success/failure and also to have the possibility to insert different storage class objects into the tests. Not sure if we ever need the latter though. Initially I thought we could test by re-applying storage classes but the fake kube api does not provide any validation. So for example if we try to change immutable field by applying a different storage class, the fake api does not prevent it.

However I still think it's a valid test and having the option to use different SC objects for tests could be useful in the future.