### PR TITLE
Bug 2059791: [vSphere CSI driver Operator] didn't update 'vsphere_csi_driver_error' metric value when fixed the error manually

### DIFF
--- a/pkg/operator/vspherecontroller/vspherecontroller.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller.go
@@ -277,8 +277,10 @@ func (c *VSphereController) blockUpgradeOrDegradeCluster(
 		utils.InstallErrorMetric.WithLabelValues(string(result.CheckStatus), clusterCondition).Set(1)
 		updateError := c.updateConditions(ctx, c.name, result, status, operatorapi.ConditionFalse)
 		return updateError, true
+	default:
+		utils.InstallErrorMetric.Reset()
+		return nil, false
 	}
-	return nil, false
 }
 
 func (c *VSphereController) runConditionalController(ctx context.Context) {


### PR DESCRIPTION
If operator creates a metric indicating error the metric is never
removed and reported even if user resolved the issue.

For example setting incorrect password for vsphere connection degrades
the operator state and emits a metric when periodic sync is performed.

If user then corrects the password and vsphere client succeeds this
metric is persisted.

This patch should ensure we reset the metric if we don't detect any
known negative state (defined in blockUpgradeOrDegradeCluster())