### PR TITLE
Bug 2071021: Enable snapshot support

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -265,7 +265,7 @@ spec:
               cpu: 10m
         - name: snapshotter-kube-rbac-proxy
           args:
-          - --secure-listen-address=0.0.0.0:9205
+          - --secure-listen-address=0.0.0.0:9206
           - --upstream=http://127.0.0.1:8205/
           - --tls-cert-file=/etc/tls/private/tls.crt
           - --tls-private-key-file=/etc/tls/private/tls.key
@@ -273,7 +273,7 @@ spec:
           image: ${KUBE_RBAC_PROXY_IMAGE}
           imagePullPolicy: IfNotPresent
           ports:
-          - containerPort: 9205
+          - containerPort: 9206
             name: snapshotter-m
             protocol: TCP
           resources:

--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -241,6 +241,48 @@ spec:
           volumeMounts:
           - mountPath: /etc/tls/private
             name: metrics-serving-cert
+        # external-snapshotter container
+        - name: csi-snapshotter
+          image: ${SNAPSHOTTER_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args:
+            - --csi-address=$(ADDRESS)
+            - --metrics-address=localhost:8205
+            - --leader-election
+            - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
+            - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
+            - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
+            - --v=${LOG_LEVEL}
+          env:
+          - name: ADDRESS
+            value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+          - mountPath: /var/lib/csi/sockets/pluginproxy/
+            name: socket-dir
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
+        - name: snapshotter-kube-rbac-proxy
+          args:
+          - --secure-listen-address=0.0.0.0:9205
+          - --upstream=http://127.0.0.1:8205/
+          - --tls-cert-file=/etc/tls/private/tls.crt
+          - --tls-private-key-file=/etc/tls/private/tls.key
+          - --logtostderr=true
+          image: ${KUBE_RBAC_PROXY_IMAGE}
+          imagePullPolicy: IfNotPresent
+          ports:
+          - containerPort: 9205
+            name: snapshotter-m
+            protocol: TCP
+          resources:
+            requests:
+              memory: 20Mi
+              cpu: 10m
+          volumeMounts:
+          - mountPath: /etc/tls/private
+            name: metrics-serving-cert
         - name: csi-liveness-probe
           image: ${LIVENESS_PROBE_IMAGE}
           imagePullPolicy: IfNotPresent

--- a/assets/service.yaml
+++ b/assets/service.yaml
@@ -29,6 +29,10 @@ spec:
     port: 446
     protocol: TCP
     targetPort: syncer-m
+  - name: snapshotter-m
+    port: 447
+    protocol: TCP
+    targetPort: snapshotter-m
   selector:
     app: vmware-vsphere-csi-driver-controller
   sessionAffinity: None

--- a/assets/servicemonitor.yaml
+++ b/assets/servicemonitor.yaml
@@ -45,6 +45,14 @@ spec:
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       serverName: vmware-vsphere-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    path: /metrics
+    port: snapshotter-m
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: vmware-vsphere-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc
   jobLabel: component
   selector:
     matchLabels:

--- a/assets/volumesnapshotclass.yaml
+++ b/assets/volumesnapshotclass.yaml
@@ -1,0 +1,8 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-vsphere-vsc
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: "true"
+driver: csi.vsphere.vmware.com
+deletionPolicy: Delete

--- a/assets/vsphere_features_config.yaml
+++ b/assets/vsphere_features_config.yaml
@@ -3,6 +3,7 @@ data:
   "csi-migration": "true" # csi-migration feature is only available for vSphere 7.0U1
   "csi-auth-check": "true"
   "online-volume-extend": "true"
+  "block-volume-snapshot": "true"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/pkg/operator/vspherecontroller/driver_starter.go
+++ b/pkg/operator/vspherecontroller/driver_starter.go
@@ -37,6 +37,7 @@ func (c *VSphereController) createCSIDriver() {
 			"controller_pdb.yaml",
 			"node_sa.yaml",
 			"csidriver.yaml",
+			"volumesnapshotclass.yaml",
 			"service.yaml",
 			"ca_configmap.yaml",
 			"rbac/csi_driver_controller_role.yaml",

--- a/pkg/operator/vspherecontroller/driver_starter.go
+++ b/pkg/operator/vspherecontroller/driver_starter.go
@@ -59,6 +59,8 @@ func (c *VSphereController) createCSIDriver() {
 			"rbac/kube_rbac_proxy_binding.yaml",
 			"rbac/prometheus_role.yaml",
 			"rbac/prometheus_rolebinding.yaml",
+			"rbac/snapshotter_role.yaml",
+			"rbac/snapshotter_binding.yaml",
 			// Static assets used by the webhook
 			"webhook/config.yaml",
 			"webhook/sa.yaml",

--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -21,4 +21,4 @@ DriverInfo:
     volumeLimits: false
     controllerExpansion: true
     nodeExpansion: true
-    snapshotDataSource: false
+    snapshotDataSource: true

--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -21,4 +21,4 @@ DriverInfo:
     volumeLimits: false
     controllerExpansion: true
     nodeExpansion: true
-    snapshotDataSource: true
+    snapshotDataSource: false


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2071021

Tests appear to be working:


```
76 pass, 164 skip (7m23s)

Storage Capabilities (guaranteed only on full CSI test suite with 0 fails)
==========================================================================
Driver short name:                         
Driver name:                               csi.vsphere.vmware.com
Storage class:                             
Supported OpenShift / CSI features:
  Persistent volumes:                      true
  Raw block mode:                          true
  FSGroup:                                 true
  Executable files on a volume:            true
  Volume snapshots:                        true
  Volume cloning:                          false
  Use volume from multiple pods on a node: false
  ReadWriteMany access mode:               false
  Volume expansion for controller:         true
  Volume expansion for node:               true
  Volume limits:                           false
  Volume can run on single node:           false
  Topology:                                false
Supported OpenShift Virtualization features:
  Raw block VM disks:                      true
  Live migration:                          false
  VM snapshots:                            true
  Storage-assisted cloning:                true

```
