### PR TITLE
Bug 2076637: Scrape CSI driver + syncer metrics

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -91,6 +91,26 @@ spec:
             requests:
               memory: 50Mi
               cpu: 10m
+        - name: driver-kube-rbac-proxy
+          args:
+          - --secure-listen-address=0.0.0.0:9201
+          - --upstream=http://127.0.0.1:2112/
+          - --tls-cert-file=/etc/tls/private/tls.crt
+          - --tls-private-key-file=/etc/tls/private/tls.key
+          - --logtostderr=true
+          image: ${KUBE_RBAC_PROXY_IMAGE}
+          imagePullPolicy: IfNotPresent
+          ports:
+          - containerPort: 9201
+            name: driver-m
+            protocol: TCP
+          resources:
+            requests:
+              memory: 20Mi
+              cpu: 10m
+          volumeMounts:
+          - mountPath: /etc/tls/private
+            name: metrics-serving-cert
         - name: csi-provisioner
           image: ${PROVISIONER_IMAGE}
           imagePullPolicy: IfNotPresent
@@ -269,6 +289,26 @@ spec:
             requests:
               memory: 50Mi
               cpu: 10m
+        - name: syncer-kube-rbac-proxy
+          args:
+          - --secure-listen-address=0.0.0.0:9205
+          - --upstream=http://127.0.0.1:2113/
+          - --tls-cert-file=/etc/tls/private/tls.crt
+          - --tls-private-key-file=/etc/tls/private/tls.key
+          - --logtostderr=true
+          image: ${KUBE_RBAC_PROXY_IMAGE}
+          imagePullPolicy: IfNotPresent
+          ports:
+          - containerPort: 9205
+            name: syncer-m
+            protocol: TCP
+          resources:
+            requests:
+              memory: 20Mi
+              cpu: 10m
+          volumeMounts:
+          - mountPath: /etc/tls/private
+            name: metrics-serving-cert
       volumes:
         - name: socket-dir
           emptyDir: {}

--- a/assets/service.yaml
+++ b/assets/service.yaml
@@ -9,6 +9,10 @@ metadata:
   namespace: openshift-cluster-csi-drivers
 spec:
   ports:
+  - name: driver-m
+    port: 442
+    protocol: TCP
+    targetPort: driver-m
   - name: provisioner-m
     port: 443
     protocol: TCP
@@ -21,6 +25,10 @@ spec:
     port: 445
     protocol: TCP
     targetPort: resizer-m
+  - name: syncer-m
+    port: 446
+    protocol: TCP
+    targetPort: syncer-m
   selector:
     app: vmware-vsphere-csi-driver-controller
   sessionAffinity: None

--- a/assets/servicemonitor.yaml
+++ b/assets/servicemonitor.yaml
@@ -8,6 +8,14 @@ spec:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     interval: 30s
     path: /metrics
+    port: driver-m
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: vmware-vsphere-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    path: /metrics
     port: provisioner-m
     scheme: https
     tlsConfig:
@@ -25,6 +33,14 @@ spec:
     interval: 30s
     path: /metrics
     port: resizer-m
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: vmware-vsphere-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    path: /metrics
+    port: syncer-m
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt


### PR DESCRIPTION
The CSI driver does not have configurable port for the metrics and due to `hostNetwork` they will be exposed on the node.

I opened https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/1720 upstream.