### PR TITLE
Bug 2089419: Don't block upgrades when another CSI driver is found

### DIFF
--- a/pkg/operator/vspherecontroller/checks/check_error.go
+++ b/pkg/operator/vspherecontroller/checks/check_error.go
@@ -26,6 +26,7 @@ type ClusterCheckStatus string
 
 const (
 	ClusterCheckAllGood             ClusterCheckStatus = "pass"
+	ClusterCheckBlockDriverInstall  ClusterCheckStatus = "installation_blocked"
 	ClusterCheckBlockUpgrade        ClusterCheckStatus = "upgrades_blocked"
 	ClusterCheckUpgradeStateUnknown ClusterCheckStatus = "upgrades_unknown"
 	ClusterCheckDegrade             ClusterCheckStatus = "degraded"
@@ -36,6 +37,7 @@ type CheckAction int
 // Ordered by severity, Pass must be 0 (for struct initialization).
 const (
 	CheckActionPass = iota
+	CheckActionBlockDriverInstall
 	CheckActionBlockUpgrade
 	CheckActionDegrade
 )
@@ -44,6 +46,8 @@ func ActionToString(a CheckAction) string {
 	switch a {
 	case CheckActionPass:
 		return "Pass"
+	case CheckActionBlockDriverInstall:
+		return "BlockInstall"
 	case CheckActionBlockUpgrade:
 		return "BlockUpgrade"
 	case CheckActionDegrade:
@@ -75,7 +79,7 @@ func makeFoundExistingDriverResult(reason error) ClusterCheckResult {
 	checkResult := ClusterCheckResult{
 		CheckStatus: CheckStatusExistingDriverFound,
 		CheckError:  reason,
-		Action:      CheckActionBlockUpgrade,
+		Action:      CheckActionBlockDriverInstall,
 		Reason:      reason.Error(),
 	}
 	return checkResult
@@ -143,6 +147,9 @@ func CheckClusterStatus(result ClusterCheckResult, apiDependencies KubeAPIInterf
 		}
 
 		return ClusterCheckBlockUpgrade, result
+
+	case CheckActionBlockDriverInstall:
+		return ClusterCheckBlockDriverInstall, result
 
 	default:
 		return ClusterCheckAllGood, result

--- a/pkg/operator/vspherecontroller/checks/check_existing_driver.go
+++ b/pkg/operator/vspherecontroller/checks/check_existing_driver.go
@@ -3,6 +3,7 @@ package checks
 import (
 	"context"
 	"fmt"
+
 	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/utils"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -16,10 +17,10 @@ func (c *CheckExistingDriver) Check(ctx context.Context, checkOpts CheckArgs) []
 			return c.checkForCSINode(ctx, checkOpts)
 		}
 		checkResult := ClusterCheckResult{
-			CheckStatus:    CheckStatusOpenshiftAPIError,
-			CheckError:     err,
-			ClusterDegrade: true,
-			Reason:         fmt.Sprintf("failed to check for existing csiDriver of type %s: %v", utils.VSphereDriverName, err),
+			CheckStatus: CheckStatusOpenshiftAPIError,
+			CheckError:  err,
+			Action:      CheckActionDegrade,
+			Reason:      fmt.Sprintf("failed to check for existing csiDriver of type %s: %v", utils.VSphereDriverName, err),
 		}
 		return []ClusterCheckResult{checkResult}
 	}
@@ -35,10 +36,10 @@ func (c *CheckExistingDriver) checkForCSINode(ctx context.Context, checkOpts Che
 	csiNodeObjects, err := checkOpts.apiClient.ListCSINodes()
 	if err != nil {
 		checkResult := ClusterCheckResult{
-			CheckStatus:    CheckStatusOpenshiftAPIError,
-			CheckError:     err,
-			ClusterDegrade: true,
-			Reason:         fmt.Sprintf("failed to list csi node objects for driver %s: %v", utils.VSphereDriverName, err),
+			CheckStatus: CheckStatusOpenshiftAPIError,
+			CheckError:  err,
+			Action:      CheckActionDegrade,
+			Reason:      fmt.Sprintf("failed to list csi node objects for driver %s: %v", utils.VSphereDriverName, err),
 		}
 		return []ClusterCheckResult{checkResult}
 	}

--- a/pkg/operator/vspherecontroller/vspherecontroller.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller.go
@@ -205,7 +205,6 @@ func (c *VSphereController) sync(ctx context.Context, syncContext factory.SyncCo
 	}
 
 	delay, result, checkRan := c.runClusterCheck(ctx, infra)
-
 	// if checks did not run
 	if !checkRan {
 		return nil
@@ -327,10 +326,10 @@ func (c *VSphereController) loginToVCenter(ctx context.Context, infra *ocpv1.Inf
 	err := c.vSphereConnection.Connect(ctx)
 	if err != nil {
 		result := checks.ClusterCheckResult{
-			CheckError:   err,
-			BlockUpgrade: true,
-			CheckStatus:  checks.CheckStatusVSphereConnectionFailed,
-			Reason:       fmt.Sprintf("Failed to connect to vSphere: %v", err),
+			CheckError:  err,
+			Action:      checks.CheckActionBlockUpgrade,
+			CheckStatus: checks.CheckStatusVSphereConnectionFailed,
+			Reason:      fmt.Sprintf("Failed to connect to vSphere: %v", err),
 		}
 		return result
 	}

--- a/pkg/operator/vspherecontroller/vspherecontroller_test.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller_test.go
@@ -158,7 +158,7 @@ func TestSync(t *testing.T) {
 				},
 				{
 					Type:   testControllerName + opv1.OperatorStatusTypeUpgradeable,
-					Status: opv1.ConditionFalse,
+					Status: opv1.ConditionTrue,
 				},
 			},
 			operandStarted: false,
@@ -177,7 +177,7 @@ func TestSync(t *testing.T) {
 				},
 				{
 					Type:   testControllerName + opv1.OperatorStatusTypeUpgradeable,
-					Status: opv1.ConditionFalse,
+					Status: opv1.ConditionTrue,
 				},
 			},
 			operandStarted: false,

--- a/pkg/operator/vspherecontroller/vspherecontroller_test.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller_test.go
@@ -311,10 +311,10 @@ func makeVsphereConnectionFunc(conn *vclib.VSphereConnection, failConnection boo
 		if failConnection {
 			err := fmt.Errorf("connection to vcenter failed")
 			result := checks.ClusterCheckResult{
-				CheckError:   err,
-				BlockUpgrade: true,
-				CheckStatus:  checks.CheckStatusVSphereConnectionFailed,
-				Reason:       fmt.Sprintf("Failed to connect to vSphere: %v", err),
+				CheckError:  err,
+				Action:      checks.CheckActionBlockUpgrade,
+				CheckStatus: checks.CheckStatusVSphereConnectionFailed,
+				Reason:      fmt.Sprintf("Failed to connect to vSphere: %v", err),
 			}
 			return nil, result, false
 		} else {


### PR DESCRIPTION
The first commit refactors two bools into enum, to be able to add a third possible outcome of a failed check.
The second commit then blocks CSI driver installation when the driver is already installed and it's not the OCP one. The operator looks "Available: true" + "Upgradeable: true", however, the Upgradeable condition has a message `found existing unsupported csi.vsphere.vmware.com driver`.

WIP:
* Add unit test.
* Think about useful alert.

@openshift/storage 