### PR TITLE
Bug 2095248: Report max. nr. of attachable volumes per node

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -68,6 +68,8 @@ spec:
               value: 3m
             - name: X_CSI_SPEC_DISABLE_LEN_CHECK
               value: "true"
+            - name: MAX_VOLUMES_PER_NODE
+              value: "59"
           ports:
             - name: healthz
               # Due to hostNetwork, this port is open on a node!

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -55,6 +55,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: MAX_VOLUMES_PER_NODE
+              value: "59"
           volumeMounts:
             - name: kubelet-dir
               mountPath: /var/lib/kubelet


### PR DESCRIPTION
`"59"` comes from https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/532a1ccb538621261c69abec0043284fb54177b8/pkg/csi/service/node.go#L40

Presence of the the env. variable ensures that the driver reports attach limits in `NodeGetInfo()` CSI call.
cc @openshift/storage 