### PR TITLE
Bug 2081557: Run at least one replica of Webhook

### DIFF
--- a/assets/webhook/deployment.yaml
+++ b/assets/webhook/deployment.yaml
@@ -8,6 +8,10 @@ spec:
   selector:
     matchLabels:
       app: vmware-vsphere-csi-driver-webhook
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/assets/webhook/pdb.yaml
+++ b/assets/webhook/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: vmware-vsphere-csi-driver-webhook-pdb
+  namespace: openshift-cluster-csi-drivers
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: vmware-vsphere-csi-driver-webhook

--- a/pkg/operator/vspherecontroller/driver_starter.go
+++ b/pkg/operator/vspherecontroller/driver_starter.go
@@ -68,6 +68,7 @@ func (c *VSphereController) createCSIDriver() {
 			"webhook/configuration.yaml",
 			"webhook/rbac/role.yaml",
 			"webhook/rbac/rolebinding.yaml",
+			"webhook/pdb.yaml",
 		},
 	).WithCSIConfigObserverController(
 		"VMwareVSphereDriverCSIConfigObserverController",


### PR DESCRIPTION
There should be always at least one replica of the webhook always running to make sure API requests are processed + the operator does not go `Available: "false"`.

* Add PodDisruptionBudget with 1 replica.
* Use `MaxUnavailable: 1`.
* Tune nr. of replicas to `1` on single-node cluster, `2` everywhere else.
* Run the webhook on regular nodes in hypershift (masters are not there)

All this code is already used in other CSI driver Deployments.

cc @openshift/storage 