### PR TITLE
Bug 2094783: storageclass should not be created for unsupported vsphere version

### DIFF
--- a/pkg/operator/vspherecontroller/vspherecontroller.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller.go
@@ -193,17 +193,6 @@ func (c *VSphereController) sync(ctx context.Context, syncContext factory.SyncCo
 		return nil
 	}
 
-	// sync storage class
-	if c.storageClassController != nil {
-		storageClassAPIDeps := c.getCheckAPIDependency(infra)
-		err = c.storageClassController.Sync(ctx, c.vSphereConnection, storageClassAPIDeps)
-		// storageclass sync will only return error if somehow updating conditions fails, in which case
-		// we can return error here and degrade the cluster
-		if err != nil {
-			return err
-		}
-	}
-
 	delay, result, checkRan := c.runClusterCheck(ctx, infra)
 	// if checks did not run
 	if !checkRan {
@@ -225,6 +214,17 @@ func (c *VSphereController) sync(ctx context.Context, syncContext factory.SyncCo
 	// if checks failed, we should exit potentially without starting CSI driver
 	if degradedOrBlockedFromUpgrades {
 		return nil
+	}
+
+	// sync storage class
+	if c.storageClassController != nil {
+		storageClassAPIDeps := c.getCheckAPIDependency(infra)
+		err = c.storageClassController.Sync(ctx, c.vSphereConnection, storageClassAPIDeps)
+		// storageclass sync will only return error if somehow updating conditions fails, in which case
+		// we can return error here and degrade the cluster
+		if err != nil {
+			return err
+		}
 	}
 
 	// if operand was not started previously and block upgrade is false and clusterdegrade is also false


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2094783
This fix just moves the storage class sync below the point at which we check `degradedOrBlockedFromUpgrades` so that we do not create the storage class if the upgrade is blocked.
/hold for testing
/cc @openshift/storage