### PR TITLE
Bug 2108054: Reset metrics only after all check succeed

### DIFF
--- a/pkg/operator/vspherecontroller/vspherecontroller.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller.go
@@ -216,6 +216,9 @@ func (c *VSphereController) sync(ctx context.Context, syncContext factory.SyncCo
 		return nil
 	}
 
+	// All checks succeeded, reset any error metrics
+	utils.InstallErrorMetric.Reset()
+
 	// sync storage class
 	if c.storageClassController != nil {
 		storageClassAPIDeps := c.getCheckAPIDependency(infra)
@@ -282,11 +285,8 @@ func (c *VSphereController) blockUpgradeOrDegradeCluster(
 		// Set Upgradeable: true with an extra message
 		updateError := c.updateConditions(ctx, c.name, result, status, operatorapi.ConditionTrue)
 		return updateError, true
-
-	default:
-		utils.InstallErrorMetric.Reset()
-		return nil, false
 	}
+	return nil, false
 }
 
 func (c *VSphereController) runConditionalController(ctx context.Context) {


### PR DESCRIPTION
`blockUpgradeOrDegradeCluster` is called twice during `sync()`, therefore it's not a good place to reset overall error metrics. Consider this scenario:
    
1st `sync()`:
* `loginToVCenter()` succeeds
    * -> the first `blockUpgradeOrDegradeCluster()` gets `CheckActionPass`
* `runClusterCheck()` fails
    * -> the second `blockUpgradeOrDegradeCluster()` gets say `CheckActionBlockDriverInstall` and sets appropriate error metric
    
2nd `sync()`:
* `loginToVCenter()` succeeds
    * -> the first `blockUpgradeOrDegradeCluster()` gets `CheckActionPass` -> this resets error metric!
* `runClusterCheck()` does not run any checks because it's too early after the previous check, therefore it does not set any    error metric
    
As result, the error metric is reset, but it should stay set until `runClusterCheck()` confirms the error has been fixed.
    
Therefore reset the metric when both `loginToVCenter` and `runClusterCheck` succeeds.

cc @openshift/storage 
