### PR TITLE
STOR-963: Add LOGGER_LEVEL env. var on debug log level

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -54,8 +54,6 @@ spec:
               value: "controller"
             - name: VSPHERE_CSI_CONFIG
               value: "/etc/kubernetes/vsphere-csi-config/cloud.conf"
-            - name: LOGGER_LEVEL
-              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: INCLUSTER_CLIENT_QPS
               value: "100"
             - name: INCLUSTER_CLIENT_BURST
@@ -315,8 +313,6 @@ spec:
               value: "30"
             - name: VSPHERE_CSI_CONFIG
               value: "/etc/kubernetes/vsphere-csi-config/cloud.conf"
-            - name: LOGGER_LEVEL
-              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: INCLUSTER_CLIENT_QPS
               value: "100"
             - name: INCLUSTER_CLIENT_BURST

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -49,8 +49,6 @@ spec:
             #   value: "/etc/kubernetes/cloud.conf"
             - name: X_CSI_SPEC_DISABLE_LEN_CHECK
               value: "true"
-            - name: LOGGER_LEVEL
-              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: CSI_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/assets/webhook/deployment.yaml
+++ b/assets/webhook/deployment.yaml
@@ -47,8 +47,6 @@ spec:
           env:
             - name: WEBHOOK_CONFIG_PATH
               value: "/etc/webhook/config/webhook.conf"
-            - name: LOGGER_LEVEL
-              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: CSI_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/pkg/operator/vspherecontroller/driver_starter.go
+++ b/pkg/operator/vspherecontroller/driver_starter.go
@@ -186,8 +186,8 @@ func WithSyncerImageHook(containerName string) deploymentcontroller.DeploymentHo
 	}
 }
 
-// WithLogLevelDeploymentHook sets the X_CSI_DEBUG environment variable to a positive
-// value when CR.LogLevel is Debug or higher.
+// WithLogLevelDeploymentHook sets the X_CSI_DEBUG and LOGGER_LEVEL environment variables
+// when CR.LogLevel is Debug or higher.
 func WithLogLevelDeploymentHook() deploymentcontroller.DeploymentHookFunc {
 	return func(opSpec *operatorapi.OperatorSpec, deployment *appsv1.Deployment) error {
 		deployment.Spec.Template.Spec.Containers = maybeAppendDebug(deployment.Spec.Template.Spec.Containers, opSpec)
@@ -195,8 +195,8 @@ func WithLogLevelDeploymentHook() deploymentcontroller.DeploymentHookFunc {
 	}
 }
 
-// WithLogLevelDaemonSetHook sets the X_CSI_DEBUG environment variable to a positive
-// value when CR.LogLevel is Debug or higher.
+// WithLogLevelDaemonSetHook sets the X_CSI_DEBUG and LOGGER_LEVEL environment variables
+// when CR.LogLevel is Debug or higher.
 func WithLogLevelDaemonSetHook() csidrivernodeservicecontroller.DaemonSetHookFunc {
 	return func(opSpec *operatorapi.OperatorSpec, ds *appsv1.DaemonSet) error {
 		ds.Spec.Template.Spec.Containers = maybeAppendDebug(ds.Spec.Template.Spec.Containers, opSpec)
@@ -205,7 +205,7 @@ func WithLogLevelDaemonSetHook() csidrivernodeservicecontroller.DaemonSetHookFun
 }
 
 // maybeAppendDebug works like the append() builtin; it returns a new slice of containers
-// with the debug env var properly set (or not).
+// with the logging env vars properly set (or not).
 func maybeAppendDebug(containers []v1.Container, opSpec *operatorapi.OperatorSpec) []v1.Container {
 	// Don't set the debug option when the current level is lower than debug
 	if loglevel.LogLevelToVerbosity(opSpec.LogLevel) < loglevel.LogLevelToVerbosity(operatorapi.Debug) {
@@ -218,6 +218,10 @@ func maybeAppendDebug(containers []v1.Container, opSpec *operatorapi.OperatorSpe
 		containers[i].Env = append(
 			containers[i].Env,
 			v1.EnvVar{Name: "X_CSI_DEBUG", Value: "true"},
+		)
+		containers[i].Env = append(
+			containers[i].Env,
+			v1.EnvVar{Name: "LOGGER_LEVEL", Value: "DEVELOPMENT"},
 		)
 	}
 	return containers

--- a/pkg/operator/vspherecontroller/webhook_controller.go
+++ b/pkg/operator/vspherecontroller/webhook_controller.go
@@ -24,6 +24,7 @@ func (c *VSphereController) createWebHookController() {
 		WithSyncerImageHook("vsphere-webhook"),
 		csidrivercontrollerservicecontroller.WithControlPlaneTopologyHook(c.apiClients.ConfigInformers),
 		csidrivercontrollerservicecontroller.WithReplicasHook(c.apiClients.KubeInformers.InformersFor("").Core().V1().Nodes().Lister()),
+		WithLogLevelDeploymentHook(),
 	)
 	c.controllers = append(c.controllers, conditionalController{
 		name:       webhookController.Name(),


### PR DESCRIPTION
When the operand log level is Debug or higher, then add `LOGGER_LEVEL=DEVELOPMENT` to get detailed logs of the CSI driver.

It's really annoying to set the env. var manually if I need the logs.

cc @openshift/storage 