### PR TITLE
Bug 2108473: Warn if multiple credentials exists in secrets

### DIFF
--- a/pkg/operator/vspherecontroller/driver_starter.go
+++ b/pkg/operator/vspherecontroller/driver_starter.go
@@ -16,6 +16,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	corev1informers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/klog/v2"
 )
 
 func (c *VSphereController) createCSIDriver() {
@@ -144,6 +145,11 @@ func WithVSphereCredentials(
 		// }
 		// So we need to figure those keys out
 		var usernameKey, passwordKey string
+
+		if len(secret.Data) > 2 {
+			klog.Warningf("CSI driver can only connect to one vcenter, more than 1 set of credentials found for CSI driver")
+		}
+
 		for k := range secret.Data {
 			if strings.HasSuffix(k, ".username") {
 				usernameKey = k


### PR DESCRIPTION
There really shouldn't be more than one set of credentials in OCP secrets because CSI driver can't support more than one vcenter anyways.

For now lets warn the users, so as it is easier to debug. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2108473