### PR TITLE
OCPBUGS-940: Rework "BlockDriverInstall" to "BlockUpgradeDriverInstall"

### DIFF
--- a/pkg/operator/vspherecontroller/checks/check_error.go
+++ b/pkg/operator/vspherecontroller/checks/check_error.go
@@ -25,21 +25,21 @@ const (
 type ClusterCheckStatus string
 
 const (
-	ClusterCheckAllGood             ClusterCheckStatus = "pass"
-	ClusterCheckBlockDriverInstall  ClusterCheckStatus = "installation_blocked"
-	ClusterCheckBlockUpgrade        ClusterCheckStatus = "upgrades_blocked"
-	ClusterCheckUpgradeStateUnknown ClusterCheckStatus = "upgrades_unknown"
-	ClusterCheckDegrade             ClusterCheckStatus = "degraded"
+	ClusterCheckAllGood                   ClusterCheckStatus = "pass"
+	ClusterCheckBlockUpgradeDriverInstall ClusterCheckStatus = "installation_blocked"
+	ClusterCheckBlockUpgrade              ClusterCheckStatus = "upgrades_blocked"
+	ClusterCheckUpgradeStateUnknown       ClusterCheckStatus = "upgrades_unknown"
+	ClusterCheckDegrade                   ClusterCheckStatus = "degraded"
 )
 
 type CheckAction int
 
 // Ordered by severity, Pass must be 0 (for struct initialization).
 const (
-	CheckActionPass = iota
-	CheckActionBlockDriverInstall
-	CheckActionBlockUpgrade          // Only block upgrade
-	CheckActionBlockUpgradeOrDegrade // Degrade if the driver is installed, block upgrade otherwise
+	CheckActionPass                      = iota
+	CheckActionBlockUpgrade              // Only block upgrade
+	CheckActionBlockUpgradeDriverInstall // Block voth upgrade and driver install
+	CheckActionBlockUpgradeOrDegrade     // Degrade if the driver is installed, block upgrade otherwise
 	CheckActionDegrade
 )
 
@@ -47,8 +47,8 @@ func ActionToString(a CheckAction) string {
 	switch a {
 	case CheckActionPass:
 		return "Pass"
-	case CheckActionBlockDriverInstall:
-		return "BlockInstall"
+	case CheckActionBlockUpgradeDriverInstall:
+		return "BlockUpgradeDriverInstall"
 	case CheckActionBlockUpgrade:
 		return "BlockUpgrade"
 	case CheckActionBlockUpgradeOrDegrade:
@@ -82,7 +82,7 @@ func makeFoundExistingDriverResult(reason error) ClusterCheckResult {
 	checkResult := ClusterCheckResult{
 		CheckStatus: CheckStatusExistingDriverFound,
 		CheckError:  reason,
-		Action:      CheckActionBlockUpgrade,
+		Action:      CheckActionBlockUpgradeDriverInstall,
 		Reason:      reason.Error(),
 	}
 	return checkResult
@@ -163,8 +163,8 @@ func CheckClusterStatus(result ClusterCheckResult, apiDependencies KubeAPIInterf
 	case CheckActionBlockUpgrade:
 		return ClusterCheckBlockUpgrade, result
 
-	case CheckActionBlockDriverInstall:
-		return ClusterCheckBlockDriverInstall, result
+	case CheckActionBlockUpgradeDriverInstall:
+		return ClusterCheckBlockUpgradeDriverInstall, result
 
 	default:
 		return ClusterCheckAllGood, result

--- a/pkg/operator/vspherecontroller/vspherecontroller.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller.go
@@ -243,7 +243,7 @@ func (c *VSphereController) sync(ctx context.Context, syncContext factory.SyncCo
 	if blockUpgrade {
 		upgradeableStatus = operatorapi.ConditionFalse
 	}
-	return c.updateConditions(ctx, c.name, checks.MakeClusterCheckResultPass(), opStatus, upgradeableStatus)
+	return c.updateConditions(ctx, c.name, result, opStatus, upgradeableStatus)
 }
 
 func (c *VSphereController) driverAlreadyStarted(ctx context.Context) (bool, error) {

--- a/pkg/operator/vspherecontroller/vspherecontroller_test.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller_test.go
@@ -150,7 +150,7 @@ func TestSync(t *testing.T) {
 					Status: opv1.ConditionFalse,
 				},
 			},
-			operandStarted: false,
+			operandStarted: true,
 		},
 		{
 			name:                         "when host version is older, block upgrades",
@@ -171,7 +171,7 @@ func TestSync(t *testing.T) {
 				},
 			},
 			expectedMetrics: `vsphere_csi_driver_error{condition="upgrade_blocked",failure_reason="check_deprecated_esxi_version"} 1`,
-			operandStarted:  false,
+			operandStarted:  true,
 		},
 		{
 			name:                         "when vcenter version is older but csi driver exists, degrade cluster",
@@ -201,8 +201,9 @@ func TestSync(t *testing.T) {
 					Status: opv1.ConditionFalse,
 				},
 			},
-			expectedMetrics: `vsphere_csi_driver_error{condition="upgrade_blocked",failure_reason="existing_driver_found"} 1`,
-			operandStarted:  false,
+			expectedMetrics: `vsphere_csi_driver_error{condition="install_blocked",failure_reason="existing_driver_found"} 1
+vsphere_csi_driver_error{condition="upgrade_blocked",failure_reason="existing_driver_found"} 1`,
+			operandStarted: false,
 		},
 		{
 			name:                         "when all configuration is right, but an existing upstream CSI node object exists",
@@ -222,8 +223,9 @@ func TestSync(t *testing.T) {
 					Status: opv1.ConditionFalse,
 				},
 			},
-			expectedMetrics: `vsphere_csi_driver_error{condition="upgrade_blocked",failure_reason="existing_driver_found"} 1`,
-			operandStarted:  false,
+			expectedMetrics: `vsphere_csi_driver_error{condition="install_blocked",failure_reason="existing_driver_found"} 1
+vsphere_csi_driver_error{condition="upgrade_blocked",failure_reason="existing_driver_found"} 1`,
+			operandStarted: false,
 		},
 		{
 			name:                         "when node hw-version was old first and got upgraded",


### PR DESCRIPTION
Because all cases where CSI driver installation is blocked should also block upgradeability of the cluster.

In addition, emit both `install_blocked` and `upgrade_blocked` metrics in this case.

Since Upgradeable condition is set in several places, return cluster upgradeability from `blockUpgradeOrDegradeCluster()` function.

@openshift/storage 