### PR TITLE
OCPBUGS-1592: Add HTTP proxy to syncer container

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -4,8 +4,8 @@ metadata:
   name: vmware-vsphere-csi-driver-controller
   namespace: openshift-cluster-csi-drivers
   annotations:
-    config.openshift.io/inject-proxy: csi-driver
-    config.openshift.io/inject-proxy-cabundle: csi-driver
+    config.openshift.io/inject-proxy: csi-driver,vsphere-syncer
+    config.openshift.io/inject-proxy-cabundle: csi-driver,vsphere-syncer
 spec:
   strategy:
     type: RollingUpdate


### PR DESCRIPTION
`vsphere-syncer` container needs HTTP proxy too.

cc @openshift/storage