### PR TITLE
 OCPBUGS-1904: Only deploy VolumeSnapshotClass when CRD exists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/openshift/api v0.0.0-20220913154013-1ef4716902a8
 	github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
 	github.com/openshift/client-go v0.0.0-20220913184216-12542f995f95
-	github.com/openshift/library-go v0.0.0-20220902131052-245d1ca16d15
+	github.com/openshift/library-go v0.0.0-20221021005159-d93563844063
 	github.com/prometheus/client_golang v1.12.1
 	github.com/spf13/cobra v1.4.0
 	github.com/vmware/govmomi v0.28.0

--- a/go.sum
+++ b/go.sum
@@ -403,8 +403,8 @@ github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d h1:RR
 github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20220913184216-12542f995f95 h1:mZ+zspDxTnqdNAhooAGYlU7GB8tw9Hp26pHIa61HfUc=
 github.com/openshift/client-go v0.0.0-20220913184216-12542f995f95/go.mod h1:I6tl0NnNMQsIlEhIKtuHoKEtyKqrlCutVaxFeHnuYNk=
-github.com/openshift/library-go v0.0.0-20220902131052-245d1ca16d15 h1:p1HJi3k1YEmLOZV+Apx8fUdQDpydkJtyYtue+vXOsck=
-github.com/openshift/library-go v0.0.0-20220902131052-245d1ca16d15/go.mod h1:KPBAXGaq7pPmA+1wUVtKr5Axg3R68IomWDkzaOxIhxM=
+github.com/openshift/library-go v0.0.0-20221021005159-d93563844063 h1:Mn2LKR04FBEiXk1g2r6cB98G7M3sCUp58qb89Uz5kcE=
+github.com/openshift/library-go v0.0.0-20221021005159-d93563844063/go.mod h1:KPBAXGaq7pPmA+1wUVtKr5Axg3R68IomWDkzaOxIhxM=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/pkg/operator/utils/apiclients.go
+++ b/pkg/operator/utils/apiclients.go
@@ -6,6 +6,7 @@ import (
 	operatorinformers "github.com/openshift/client-go/operator/informers/externalversions"
 	clustercsidriverinformer "github.com/openshift/client-go/operator/informers/externalversions/operator/v1"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	apiextclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/dynamic"
 	v1 "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -18,6 +19,8 @@ type APIClient struct {
 	OperatorClient v1helpers.OperatorClientWithFinalizers
 	// Kubernetes API client
 	KubeClient kubernetes.Interface
+	// API extension client
+	ApiExtClient apiextclient.Interface
 	// Kubernetes API informers, per namespace
 	KubeInformers v1helpers.KubeInformersForNamespaces
 

--- a/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/builder.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/builder.go
@@ -269,7 +269,7 @@ func (b *ControllerBuilder) Run(ctx context.Context, config *unstructured.Unstru
 
 	var server *genericapiserver.GenericAPIServer
 	if b.servingInfo != nil {
-		serverConfig, err := serving.ToServerConfig(ctx, *b.servingInfo, *b.authenticationConfig, *b.authorizationConfig, kubeConfig)
+		serverConfig, err := serving.ToServerConfig(ctx, *b.servingInfo, *b.authenticationConfig, *b.authorizationConfig, kubeConfig, kubeClient, b.leaderElection)
 		if err != nil {
 			return err
 		}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -368,7 +368,7 @@ func (c *StaticResourceController) Sync(ctx context.Context, syncContext factory
 }
 
 func (c *StaticResourceController) Name() string {
-	return "StaticResourceController"
+	return c.name
 }
 
 func (c *StaticResourceController) RelatedObjects() ([]configv1.ObjectReference, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -248,7 +248,7 @@ github.com/openshift/client-go/operator/informers/externalversions/operator/v1
 github.com/openshift/client-go/operator/informers/externalversions/operator/v1alpha1
 github.com/openshift/client-go/operator/listers/operator/v1
 github.com/openshift/client-go/operator/listers/operator/v1alpha1
-# github.com/openshift/library-go v0.0.0-20220902131052-245d1ca16d15
+# github.com/openshift/library-go v0.0.0-20221021005159-d93563844063
 ## explicit; go 1.18
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer
 github.com/openshift/library-go/pkg/config/client


### PR DESCRIPTION
When the cluster-csi-snapshot-controller-operator is not deployed, (through the CSISnapshot capability) the VolumeSnapshotClass CRD is not created at all.

In that case, it doesn't make sense to deploy the CR, otherwise the operator gets degraded.

CC @openshift/storage
