### PR TITLE
Bug 2106736: Add multiplePVsSameID capability

### DIFF
--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -22,3 +22,4 @@ DriverInfo:
     controllerExpansion: true
     nodeExpansion: true
     snapshotDataSource: false
+    multiplePVsSameID: true


### PR DESCRIPTION
This CSI driver can handle multiple PVs that have the same VolumeHandle used on the same node.

cc @openshift/storage