### PR TITLE
Bug 2106736: Fix multiplePVsSameID value in tests

### DIFF
--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -22,4 +22,4 @@ DriverInfo:
     controllerExpansion: true
     nodeExpansion: true
     snapshotDataSource: false
-    multiplePVsSameID: true
+    multiplePVsSameID: false


### PR DESCRIPTION
This CSI driver actually [does not support multiple PVs with the same VolumeHandle](https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/1913). It is the reason why multiplePVsSameID capability was introduced.

@openshift/storage 