### PR TITLE
STOR-1145: Add metric for topology

### DIFF
--- a/pkg/operator/utils/metric.go
+++ b/pkg/operator/utils/metric.go
@@ -8,6 +8,18 @@ import (
 const (
 	failureReason = "failure_reason"
 	condition     = "condition"
+
+	topologyTagSource                 = "source"
+	topologyTagSourceClusterCSIDriver = "clustercsidriver"
+	topologyTagSourceInfrastructure   = "infrastructure"
+
+	domainScope         = "scope"
+	scopeRegions        = "regions"
+	scopeZones          = "zones"
+	scopeVCenters       = "vcenters"
+	scopeDatacenters    = "datacenters"
+	scopeDatastores     = "datastores"
+	scopeFailureDomains = "failure_domains"
 )
 
 var (
@@ -19,8 +31,27 @@ var (
 		},
 		[]string{failureReason, condition},
 	)
+
+	TopologyTagsMetric = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Name:           "vsphere_topology_tags",
+			Help:           "Number of vSphere topology tags",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{topologyTagSource},
+	)
+	InfrastructureFailureDomains = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Name:           "vsphere_infrastructure_failure_domains",
+			Help:           "Number of vSphere failure domains",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{domainScope},
+	)
 )
 
 func init() {
 	legacyregistry.MustRegister(InstallErrorMetric)
+	legacyregistry.MustRegister(TopologyTagsMetric)
+	legacyregistry.MustRegister(InfrastructureFailureDomains)
 }

--- a/pkg/operator/utils/topology.go
+++ b/pkg/operator/utils/topology.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	v1 "github.com/openshift/api/config/v1"
+	cfgv1 "github.com/openshift/api/config/v1"
 	opv1 "github.com/openshift/api/operator/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/legacy-cloud-providers/vsphere"
@@ -15,7 +15,7 @@ const (
 	defaultOpenshiftRegionCategory = "openshift-region"
 )
 
-func GetTopologyCategories(clusterCSIDriver *opv1.ClusterCSIDriver, infra *v1.Infrastructure) []string {
+func GetInfraTopologyCategories(infra *cfgv1.Infrastructure) []string {
 	vSpherePlatformConfig := infra.Spec.PlatformSpec.VSphere
 	if vSpherePlatformConfig != nil {
 		failureDomains := vSpherePlatformConfig.FailureDomains
@@ -23,7 +23,10 @@ func GetTopologyCategories(clusterCSIDriver *opv1.ClusterCSIDriver, infra *v1.In
 			return []string{defaultOpenshiftZoneCategory, defaultOpenshiftRegionCategory}
 		}
 	}
+	return []string{}
+}
 
+func GetCSIDriverTopologyCategories(clusterCSIDriver *opv1.ClusterCSIDriver) []string {
 	driverConfig := clusterCSIDriver.Spec.DriverConfig
 	if driverConfig.DriverType == opv1.VSphereDriverType {
 		vSphereConfig := driverConfig.VSphere
@@ -32,6 +35,14 @@ func GetTopologyCategories(clusterCSIDriver *opv1.ClusterCSIDriver, infra *v1.In
 		}
 	}
 	return []string{}
+}
+
+func GetTopologyCategories(clusterCSIDriver *opv1.ClusterCSIDriver, infra *cfgv1.Infrastructure) []string {
+	infraCategories := GetInfraTopologyCategories(infra)
+	if len(infraCategories) > 0 {
+		return infraCategories
+	}
+	return GetCSIDriverTopologyCategories(clusterCSIDriver)
 }
 
 func GetDatacenters(config *vsphere.VSphereConfig) ([]string, error) {
@@ -48,4 +59,78 @@ func GetDatacenters(config *vsphere.VSphereConfig) ([]string, error) {
 		datacenters = strings.Split(virtualCenterConfig.Datacenters, ",")
 	}
 	return datacenters, nil
+}
+
+func UpdateMetrics(infra *cfgv1.Infrastructure, clusterCSIDriver *opv1.ClusterCSIDriver) {
+	domains := GetCSIDriverTopologyCategories(clusterCSIDriver)
+	TopologyTagsMetric.WithLabelValues(topologyTagSourceClusterCSIDriver).Set(float64(len(domains)))
+	domains = GetInfraTopologyCategories(infra)
+	TopologyTagsMetric.WithLabelValues(topologyTagSourceInfrastructure).Set(float64(len(domains)))
+
+	vSpherePlatformConfig := infra.Spec.PlatformSpec.VSphere
+	if vSpherePlatformConfig == nil {
+		// Reset all metrics
+		InfrastructureFailureDomains.WithLabelValues(scopeDatacenters).Set(0.0)
+		InfrastructureFailureDomains.WithLabelValues(scopeDatastores).Set(0.0)
+		InfrastructureFailureDomains.WithLabelValues(scopeRegions).Set(0.0)
+		InfrastructureFailureDomains.WithLabelValues(scopeZones).Set(0.0)
+		InfrastructureFailureDomains.WithLabelValues(scopeVCenters).Set(0.0)
+		InfrastructureFailureDomains.WithLabelValues(scopeFailureDomains).Set(0.0)
+		return
+	}
+
+	// Report detail topology from Infrastructure (ClusterCSIDriver does not have that level of detail)
+	datacenterDatastores := map[string]sets.String{} // datacenter -> list of its datastores
+	regionZones := map[string]sets.String{}          // region -> list of its zones
+	vCenters := sets.NewString()                     // list of vCenters
+
+	for _, fd := range vSpherePlatformConfig.FailureDomains {
+		region := fd.Region
+		zone := fd.Zone
+		if region != "" {
+			zones := regionZones[region]
+			if zones == nil {
+				zones = sets.NewString()
+			}
+			if zone != "" {
+				zones.Insert(zone)
+			}
+			regionZones[region] = zones
+		}
+
+		datacenter := fd.Topology.Datacenter
+		datastore := fd.Topology.Datastore
+		if datacenter != "" {
+			datastores := datacenterDatastores[datacenter]
+			if datastores == nil {
+				datastores = sets.NewString()
+			}
+			if datastore != "" {
+				datastores.Insert(datastore)
+			}
+			datacenterDatastores[datacenter] = datastores
+		}
+
+		vCenter := fd.Server
+		if vCenter != "" {
+			vCenters.Insert(vCenter)
+		}
+	}
+
+	InfrastructureFailureDomains.WithLabelValues(scopeDatacenters).Set(float64(len(datacenterDatastores)))
+	datastoreCount := 0
+	for _, datastores := range datacenterDatastores {
+		datastoreCount += datastores.Len()
+	}
+	InfrastructureFailureDomains.WithLabelValues(scopeDatastores).Set(float64(datastoreCount))
+
+	InfrastructureFailureDomains.WithLabelValues(scopeRegions).Set(float64(len(regionZones)))
+	zoneCount := 0
+	for _, zones := range regionZones {
+		zoneCount += zones.Len()
+	}
+	InfrastructureFailureDomains.WithLabelValues(scopeZones).Set(float64(zoneCount))
+
+	InfrastructureFailureDomains.WithLabelValues(scopeVCenters).Set(float64(len(vCenters)))
+	InfrastructureFailureDomains.WithLabelValues(scopeFailureDomains).Set(float64(len(vSpherePlatformConfig.FailureDomains)))
 }

--- a/pkg/operator/utils/topology_test.go
+++ b/pkg/operator/utils/topology_test.go
@@ -1,0 +1,348 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	cfgv1 "github.com/openshift/api/config/v1"
+	opv1 "github.com/openshift/api/operator/v1"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
+)
+
+func TestUpdateMetrics(t *testing.T) {
+	emptyClusterCSIDriver := &opv1.ClusterCSIDriver{
+		Spec: opv1.ClusterCSIDriverSpec{
+			DriverConfig: opv1.CSIDriverConfigSpec{
+				DriverType: opv1.VSphereDriverType,
+				VSphere: &opv1.VSphereCSIDriverConfigSpec{
+					TopologyCategories: []string{},
+				},
+			},
+		}}
+
+	nilClusterCSIDriver := &opv1.ClusterCSIDriver{
+		Spec: opv1.ClusterCSIDriverSpec{
+			DriverConfig: opv1.CSIDriverConfigSpec{
+				DriverType: opv1.VSphereDriverType,
+				VSphere:    nil,
+			},
+		}}
+
+	twoCategoriesClusterCSIDriver := &opv1.ClusterCSIDriver{
+		Spec: opv1.ClusterCSIDriverSpec{
+			DriverConfig: opv1.CSIDriverConfigSpec{
+				DriverType: opv1.VSphereDriverType,
+				VSphere: &opv1.VSphereCSIDriverConfigSpec{
+					TopologyCategories: []string{"region", "zone"},
+				},
+			},
+		}}
+
+	emptyInfra := &cfgv1.Infrastructure{
+		Spec: cfgv1.InfrastructureSpec{
+			PlatformSpec: cfgv1.PlatformSpec{
+				Type: cfgv1.VSpherePlatformType,
+				VSphere: &cfgv1.VSpherePlatformSpec{
+					FailureDomains: nil,
+				},
+			},
+		},
+	}
+
+	nilInfra := &cfgv1.Infrastructure{
+		Spec: cfgv1.InfrastructureSpec{
+			PlatformSpec: cfgv1.PlatformSpec{
+				Type:    cfgv1.VSpherePlatformType,
+				VSphere: nil,
+			},
+		},
+	}
+
+	// Note: region corresponds to datacenter and zone to datastore in these tests,
+	// to save us from two sets of tests.
+	oneRegionTwoZonesInfra := emptyInfra.DeepCopy()
+	oneRegionTwoZonesInfra.Spec.PlatformSpec.VSphere.FailureDomains = []cfgv1.VSpherePlatformFailureDomainSpec{
+		{
+			Name:   "region1-zone1",
+			Region: "region1",
+			Zone:   "zone1",
+			Server: "vcenter1",
+			Topology: cfgv1.VSpherePlatformTopology{
+				Datacenter:     "datacenter1",
+				ComputeCluster: "computecluster1",
+				Networks:       nil,
+				Datastore:      "datastore1",
+				ResourcePool:   "resourcepool1",
+				Folder:         "folder1",
+			},
+		},
+		{
+			Name:   "region1-zone2",
+			Region: "region1",
+			Zone:   "zone2",
+			Server: "vcenter1",
+			Topology: cfgv1.VSpherePlatformTopology{
+				Datacenter:     "datacenter1",
+				ComputeCluster: "computecluster1",
+				Networks:       nil,
+				Datastore:      "datastore2",
+				ResourcePool:   "resourcepool2",
+				Folder:         "folder2",
+			},
+		},
+	}
+
+	twoRegionsTwoZonesInfra := emptyInfra.DeepCopy()
+	twoRegionsTwoZonesInfra.Spec.PlatformSpec.VSphere.FailureDomains = []cfgv1.VSpherePlatformFailureDomainSpec{
+		{
+			Name:   "region1-zone1",
+			Region: "region1",
+			Zone:   "zone1",
+			Server: "vcenter1",
+			Topology: cfgv1.VSpherePlatformTopology{
+				Datacenter:     "datacenter1",
+				ComputeCluster: "computecluster1",
+				Networks:       nil,
+				Datastore:      "datastore1",
+				ResourcePool:   "resourcepool1",
+				Folder:         "folder1",
+			},
+		},
+		{
+			Name:   "region1-zone2",
+			Region: "region1",
+			Zone:   "zone2",
+			Server: "vcenter1",
+			Topology: cfgv1.VSpherePlatformTopology{
+				Datacenter:     "datacenter1",
+				ComputeCluster: "computecluster1",
+				Networks:       nil,
+				Datastore:      "datastore2",
+				ResourcePool:   "resourcepool2",
+				Folder:         "folder2",
+			},
+		},
+		{
+			Name:   "region2-zone1",
+			Region: "region2",
+			Zone:   "zone1",
+			Server: "vcenter1",
+			Topology: cfgv1.VSpherePlatformTopology{
+				Datacenter:     "datacenter2",
+				ComputeCluster: "computecluster2",
+				Networks:       nil,
+				Datastore:      "datastore1",
+				ResourcePool:   "resourcepool1",
+				Folder:         "folder1",
+			},
+		},
+		{
+			Name:   "region2-zone2",
+			Region: "region2",
+			Zone:   "zone2",
+			Server: "vcenter1",
+			Topology: cfgv1.VSpherePlatformTopology{
+				Datacenter:     "datacenter2",
+				ComputeCluster: "computecluster2",
+				Networks:       nil,
+				Datastore:      "datastore2",
+				ResourcePool:   "resourcepool2",
+				Folder:         "folder2",
+			},
+		},
+	}
+
+	twoVCentersTwoRegionsTwoZonesInfra := emptyInfra.DeepCopy()
+	twoVCentersTwoRegionsTwoZonesInfra.Spec.PlatformSpec.VSphere.FailureDomains = []cfgv1.VSpherePlatformFailureDomainSpec{
+		{
+			Name:   "region1-zone1",
+			Region: "region1",
+			Zone:   "zone1",
+			Server: "vcenter1",
+			Topology: cfgv1.VSpherePlatformTopology{
+				Datacenter:     "datacenter1",
+				ComputeCluster: "computecluster1",
+				Networks:       nil,
+				Datastore:      "datastore1",
+				ResourcePool:   "resourcepool1",
+				Folder:         "folder1",
+			},
+		},
+		{
+			Name:   "region1-zone2",
+			Region: "region1",
+			Zone:   "zone2",
+			Server: "vcenter1",
+			Topology: cfgv1.VSpherePlatformTopology{
+				Datacenter:     "datacenter1",
+				ComputeCluster: "computecluster1",
+				Networks:       nil,
+				Datastore:      "datastore2",
+				ResourcePool:   "resourcepool2",
+				Folder:         "folder2",
+			},
+		},
+		{
+			Name:   "region2-zone1",
+			Region: "region2",
+			Zone:   "zone1",
+			Server: "vcenter2",
+			Topology: cfgv1.VSpherePlatformTopology{
+				Datacenter:     "datacenter2",
+				ComputeCluster: "computecluster2",
+				Networks:       nil,
+				Datastore:      "datastore1",
+				ResourcePool:   "resourcepool1",
+				Folder:         "folder1",
+			},
+		},
+		{
+			Name:   "region2-zone2",
+			Region: "region2",
+			Zone:   "zone2",
+			Server: "vcenter2",
+			Topology: cfgv1.VSpherePlatformTopology{
+				Datacenter:     "datacenter2",
+				ComputeCluster: "computecluster2",
+				Networks:       nil,
+				Datastore:      "datastore2",
+				ResourcePool:   "resourcepool2",
+				Folder:         "folder2",
+			},
+		},
+	}
+
+	tests := []struct {
+		name             string
+		infra            *cfgv1.Infrastructure
+		clusterCSIDriver *opv1.ClusterCSIDriver
+		expectedMetrics  string
+	}{
+		{
+			name:             "empty topology",
+			infra:            emptyInfra,
+			clusterCSIDriver: emptyClusterCSIDriver,
+			expectedMetrics: `
+# HELP vsphere_infrastructure_failure_domains [ALPHA] Number of vSphere failure domains
+# TYPE vsphere_infrastructure_failure_domains gauge
+vsphere_infrastructure_failure_domains{scope="datacenters"} 0
+vsphere_infrastructure_failure_domains{scope="datastores"} 0
+vsphere_infrastructure_failure_domains{scope="failure_domains"} 0
+vsphere_infrastructure_failure_domains{scope="regions"} 0
+vsphere_infrastructure_failure_domains{scope="vcenters"} 0
+vsphere_infrastructure_failure_domains{scope="zones"} 0
+# HELP vsphere_topology_tags [ALPHA] Number of vSphere topology tags
+# TYPE vsphere_topology_tags gauge
+vsphere_topology_tags{source="clustercsidriver"} 0
+vsphere_topology_tags{source="infrastructure"} 0
+`,
+		},
+		{
+			name:             "nil topology",
+			infra:            nilInfra,
+			clusterCSIDriver: nilClusterCSIDriver,
+			expectedMetrics: `
+# HELP vsphere_infrastructure_failure_domains [ALPHA] Number of vSphere failure domains
+# TYPE vsphere_infrastructure_failure_domains gauge
+vsphere_infrastructure_failure_domains{scope="datacenters"} 0
+vsphere_infrastructure_failure_domains{scope="datastores"} 0
+vsphere_infrastructure_failure_domains{scope="failure_domains"} 0
+vsphere_infrastructure_failure_domains{scope="regions"} 0
+vsphere_infrastructure_failure_domains{scope="vcenters"} 0
+vsphere_infrastructure_failure_domains{scope="zones"} 0
+# HELP vsphere_topology_tags [ALPHA] Number of vSphere topology tags
+# TYPE vsphere_topology_tags gauge
+vsphere_topology_tags{source="clustercsidriver"} 0
+vsphere_topology_tags{source="infrastructure"} 0
+`,
+		},
+		{
+			name:             "clustercsidriver topology",
+			infra:            emptyInfra,
+			clusterCSIDriver: twoCategoriesClusterCSIDriver,
+			expectedMetrics: `
+# HELP vsphere_infrastructure_failure_domains [ALPHA] Number of vSphere failure domains
+# TYPE vsphere_infrastructure_failure_domains gauge
+vsphere_infrastructure_failure_domains{scope="datacenters"} 0
+vsphere_infrastructure_failure_domains{scope="datastores"} 0
+vsphere_infrastructure_failure_domains{scope="failure_domains"} 0
+vsphere_infrastructure_failure_domains{scope="regions"} 0
+vsphere_infrastructure_failure_domains{scope="vcenters"} 0
+vsphere_infrastructure_failure_domains{scope="zones"} 0
+# HELP vsphere_topology_tags [ALPHA] Number of vSphere topology tags
+# TYPE vsphere_topology_tags gauge
+vsphere_topology_tags{source="clustercsidriver"} 2
+vsphere_topology_tags{source="infrastructure"} 0
+`,
+		},
+		{
+			name:             "infra topology 1 region 2 zones",
+			infra:            oneRegionTwoZonesInfra,
+			clusterCSIDriver: emptyClusterCSIDriver,
+			expectedMetrics: `
+# HELP vsphere_infrastructure_failure_domains [ALPHA] Number of vSphere failure domains
+# TYPE vsphere_infrastructure_failure_domains gauge
+vsphere_infrastructure_failure_domains{scope="datacenters"} 1
+vsphere_infrastructure_failure_domains{scope="datastores"} 2
+vsphere_infrastructure_failure_domains{scope="failure_domains"} 2
+vsphere_infrastructure_failure_domains{scope="regions"} 1
+vsphere_infrastructure_failure_domains{scope="vcenters"} 1
+vsphere_infrastructure_failure_domains{scope="zones"} 2
+# HELP vsphere_topology_tags [ALPHA] Number of vSphere topology tags
+# TYPE vsphere_topology_tags gauge
+vsphere_topology_tags{source="clustercsidriver"} 0
+vsphere_topology_tags{source="infrastructure"} 2
+`,
+		},
+		{
+			name:             "infra topology 2 regions 2 zones each",
+			infra:            twoRegionsTwoZonesInfra,
+			clusterCSIDriver: emptyClusterCSIDriver,
+			expectedMetrics: `
+# HELP vsphere_infrastructure_failure_domains [ALPHA] Number of vSphere failure domains
+# TYPE vsphere_infrastructure_failure_domains gauge
+vsphere_infrastructure_failure_domains{scope="datacenters"} 2
+vsphere_infrastructure_failure_domains{scope="datastores"} 4
+vsphere_infrastructure_failure_domains{scope="failure_domains"} 4
+vsphere_infrastructure_failure_domains{scope="regions"} 2
+vsphere_infrastructure_failure_domains{scope="vcenters"} 1
+vsphere_infrastructure_failure_domains{scope="zones"} 4
+# HELP vsphere_topology_tags [ALPHA] Number of vSphere topology tags
+# TYPE vsphere_topology_tags gauge
+vsphere_topology_tags{source="clustercsidriver"} 0
+vsphere_topology_tags{source="infrastructure"} 2
+`,
+		},
+		{
+			name:             "infra topology 2 vCenters",
+			infra:            twoVCentersTwoRegionsTwoZonesInfra,
+			clusterCSIDriver: emptyClusterCSIDriver,
+			expectedMetrics: `
+# HELP vsphere_infrastructure_failure_domains [ALPHA] Number of vSphere failure domains
+# TYPE vsphere_infrastructure_failure_domains gauge
+vsphere_infrastructure_failure_domains{scope="datacenters"} 2
+vsphere_infrastructure_failure_domains{scope="datastores"} 4
+vsphere_infrastructure_failure_domains{scope="failure_domains"} 4
+vsphere_infrastructure_failure_domains{scope="regions"} 2
+vsphere_infrastructure_failure_domains{scope="vcenters"} 2
+vsphere_infrastructure_failure_domains{scope="zones"} 4
+# HELP vsphere_topology_tags [ALPHA] Number of vSphere topology tags
+# TYPE vsphere_topology_tags gauge
+vsphere_topology_tags{source="clustercsidriver"} 0
+vsphere_topology_tags{source="infrastructure"} 2
+`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Reset metrics from previous tests. Note: the tests can't run in parallel!
+			legacyregistry.Reset()
+
+			UpdateMetrics(test.infra, test.clusterCSIDriver)
+			if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(test.expectedMetrics), "vsphere_topology_tags", "vsphere_infrastructure_failure_domains"); err != nil {
+				t.Errorf("Unexpected metric: %s", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- `vsphere_topology_tags_total` reports how many tag categories are configured for the CSI driver topology. It has label "`source`" with two values:
      - "`clustercsidriver`" - nr. of topology categories configured in the  ClusterCSIDriver instance
      - "`infrastructure`" - always 2, if infrastructure describes any topology (openshift-region and openshift-zone categories are used by OCP in this case), 0 otherwise.
    
- `vsphere_infrastructure_failure_domains_total` - reports total nr. of configured vSphere failure domains in the Infrastructure instance. Has label "`scope`" with values:
      - regions
      - zones
      - vcenters
      - datacenters
      - datastores
      - failure_domains


cc @openshift/storage 