### PR TITLE
OCPBUGS-11294: Add CSI migration metric

### DIFF
--- a/pkg/operator/utils/metric.go
+++ b/pkg/operator/utils/metric.go
@@ -6,8 +6,9 @@ import (
 )
 
 const (
-	failureReason = "failure_reason"
-	condition     = "condition"
+	failureReason   = "failure_reason"
+	condition       = "condition"
+	migrationStatus = "status"
 
 	topologyTagSource                 = "source"
 	topologyTagSourceClusterCSIDriver = "clustercsidriver"
@@ -48,10 +49,19 @@ var (
 		},
 		[]string{domainScope},
 	)
+	CSIMigrationStatus = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Name:           "vsphere_csi_migration",
+			Help:           "CSI migration status for vSphere volumes",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{migrationStatus},
+	)
 )
 
 func init() {
 	legacyregistry.MustRegister(InstallErrorMetric)
 	legacyregistry.MustRegister(TopologyTagsMetric)
 	legacyregistry.MustRegister(InfrastructureFailureDomains)
+	legacyregistry.MustRegister(CSIMigrationStatus)
 }

--- a/pkg/operator/utils/topology.go
+++ b/pkg/operator/utils/topology.go
@@ -61,7 +61,16 @@ func GetDatacenters(config *vsphere.VSphereConfig) ([]string, error) {
 	return datacenters, nil
 }
 
-func UpdateMetrics(infra *cfgv1.Infrastructure, clusterCSIDriver *opv1.ClusterCSIDriver) {
+func UpdateMetrics(infra *cfgv1.Infrastructure, clusterCSIDriver *opv1.ClusterCSIDriver, storage *opv1.Storage) {
+	var vSphereStorageDriverValues = []opv1.StorageDriverType{"", opv1.LegacyDeprecatedInTreeDriver, opv1.CSIWithMigrationDriver}
+	for _, value := range vSphereStorageDriverValues {
+		if storage.Spec.VSphereStorageDriver == value {
+			CSIMigrationStatus.WithLabelValues(string(value)).Set(1.0)
+		} else {
+			CSIMigrationStatus.WithLabelValues(string(value)).Set(0.0)
+		}
+	}
+
 	domains := GetCSIDriverTopologyCategories(clusterCSIDriver)
 	TopologyTagsMetric.WithLabelValues(topologyTagSourceClusterCSIDriver).Set(float64(len(domains)))
 	domains = GetInfraTopologyCategories(infra)

--- a/pkg/operator/utils/topology_test.go
+++ b/pkg/operator/utils/topology_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestUpdateMetrics(t *testing.T) {
+	storage := &opv1.Storage{Spec: opv1.StorageSpec{VSphereStorageDriver: opv1.CSIWithMigrationDriver}}
+
 	emptyClusterCSIDriver := &opv1.ClusterCSIDriver{
 		Spec: opv1.ClusterCSIDriverSpec{
 			DriverConfig: opv1.CSIDriverConfigSpec{
@@ -375,8 +377,7 @@ vsphere_topology_tags{source="infrastructure"} 0
 		t.Run(test.name, func(t *testing.T) {
 			// Reset metrics from previous tests. Note: the tests can't run in parallel!
 			legacyregistry.Reset()
-
-			UpdateMetrics(test.infra, test.clusterCSIDriver)
+			UpdateMetrics(test.infra, test.clusterCSIDriver, storage)
 			if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(test.expectedMetrics), "vsphere_topology_tags", "vsphere_infrastructure_failure_domains"); err != nil {
 				t.Errorf("Unexpected metric: %s", err)
 			}

--- a/pkg/operator/vspherecontroller/vspherecontroller.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller.go
@@ -66,6 +66,7 @@ type VSphereController struct {
 const (
 	cloudConfigNamespace              = "openshift-config"
 	infraGlobalName                   = "cluster"
+	storageOperatorName               = "cluster"
 	secretName                        = "vmware-vsphere-cloud-credentials"
 	trustedCAConfigMap                = "vmware-vsphere-csi-driver-trusted-ca-bundle"
 	defaultNamespace                  = "openshift-cluster-csi-drivers"
@@ -175,7 +176,12 @@ func (c *VSphereController) sync(ctx context.Context, syncContext factory.SyncCo
 		return err
 	}
 
-	utils.UpdateMetrics(infra, clusterCSIDriver)
+	storage, err := c.storageLister.Get(storageOperatorName)
+	if err != nil {
+		return err
+	}
+
+	utils.UpdateMetrics(infra, clusterCSIDriver, storage)
 
 	driverCheckFlag, err := c.driverAlreadyStarted(ctx)
 	if err != nil {


### PR DESCRIPTION
Based on https://github.com/openshift/vmware-vsphere-csi-driver-operator/pull/145

Add `vsphere_csi_migration` metric that shows value of `storage.spec.vsphereStorageDriver` as a metric.