### PR TITLE
OCPBUGS-12712: Add backoff for successful storage policy creations

### DIFF
--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -65,8 +65,6 @@ func NewTargetConfigController(
 		c.sync,
 	).ResyncEvery(
 		20*time.Minute, // TODO: figure out what's the idead resync time for this controller
-	).WithSyncDegradedOnError(
-		operatorClient,
 	).ToController(
 		c.name,
 		recorder.WithComponentSuffix("target-config-controller-"+strings.ToLower(name)),


### PR DESCRIPTION
Also remove targetconfigController

Fixes https://issues.redhat.com/browse/OCPBUGS-12712