### PR TITLE
STOR-1304: Restart controller pods if metrics serving cert or webhook secret changed

### DIFF
--- a/pkg/operator/vspherecontroller/driver_starter.go
+++ b/pkg/operator/vspherecontroller/driver_starter.go
@@ -109,7 +109,7 @@ func (c *VSphereController) createCSIDriver() {
 			c.apiClients.ConfigMapInformer.Informer(),
 			c.apiClients.NodeInformer.Informer(),
 		},
-		WithVSphereCredentials(defaultNamespace, secretName, c.apiClients.SecretInformer),
+		WithVSphereCredentials(defaultNamespace, cloudCredSecretName, c.apiClients.SecretInformer),
 		WithSyncerImageHook("vsphere-syncer"),
 		WithLogLevelDeploymentHook(),
 		c.topologyHook,
@@ -121,7 +121,12 @@ func (c *VSphereController) createCSIDriver() {
 		),
 		csidrivercontrollerservicecontroller.WithSecretHashAnnotationHook(
 			defaultNamespace,
-			secretName,
+			cloudCredSecretName,
+			c.apiClients.SecretInformer,
+		),
+		csidrivercontrollerservicecontroller.WithSecretHashAnnotationHook(
+			defaultNamespace,
+			metricsCertSecretName,
 			c.apiClients.SecretInformer,
 		),
 		csidrivercontrollerservicecontroller.WithReplicasHook(c.nodeLister),

--- a/pkg/operator/vspherecontroller/vspherecontroller.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller.go
@@ -65,7 +65,8 @@ type VSphereController struct {
 const (
 	cloudConfigNamespace              = "openshift-config"
 	infraGlobalName                   = "cluster"
-	secretName                        = "vmware-vsphere-cloud-credentials"
+	cloudCredSecretName               = "vmware-vsphere-cloud-credentials"
+	metricsCertSecretName             = "vmware-vsphere-csi-driver-controller-metrics-serving-cert"
 	trustedCAConfigMap                = "vmware-vsphere-csi-driver-trusted-ca-bundle"
 	defaultNamespace                  = "openshift-cluster-csi-drivers"
 	driverOperandName                 = "vmware-vsphere-csi-driver"
@@ -415,19 +416,19 @@ func (c *VSphereController) createVCenterConnection(ctx context.Context, infra *
 		return err
 	}
 
-	secret, err := c.secretLister.Secrets(c.targetNamespace).Get(secretName)
+	secret, err := c.secretLister.Secrets(c.targetNamespace).Get(cloudCredSecretName)
 	if err != nil {
 		return err
 	}
 	userKey := cfg.Workspace.VCenterIP + "." + "username"
 	username, ok := secret.Data[userKey]
 	if !ok {
-		return fmt.Errorf("error parsing secret %q: key %q not found", secretName, userKey)
+		return fmt.Errorf("error parsing secret %q: key %q not found", cloudCredSecretName, userKey)
 	}
 	passwordKey := cfg.Workspace.VCenterIP + "." + "password"
 	password, ok := secret.Data[passwordKey]
 	if !ok {
-		return fmt.Errorf("error parsing secret %q: key %q not found", secretName, passwordKey)
+		return fmt.Errorf("error parsing secret %q: key %q not found", cloudCredSecretName, passwordKey)
 	}
 
 	vs := vclib.NewVSphereConnection(string(username), string(password), cfg)

--- a/pkg/operator/vspherecontroller/vspherecontroller.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller.go
@@ -67,6 +67,7 @@ const (
 	infraGlobalName                   = "cluster"
 	cloudCredSecretName               = "vmware-vsphere-cloud-credentials"
 	metricsCertSecretName             = "vmware-vsphere-csi-driver-controller-metrics-serving-cert"
+	webhookSecretName                 = "vmware-vsphere-csi-driver-webhook-secret"
 	trustedCAConfigMap                = "vmware-vsphere-csi-driver-trusted-ca-bundle"
 	defaultNamespace                  = "openshift-cluster-csi-drivers"
 	driverOperandName                 = "vmware-vsphere-csi-driver"


### PR DESCRIPTION
Adding WithSecretHashAnnotationHook() for vmware-vsphere-csi-driver-controller-metrics-serving-cert ensures that new annotation is published in vmware-vsphere-csi-driver-controller deployment. This, in turn, leads to controller pods restart.

Similarly, adding WithSecretHashAnnotationHook() for vmware-vsphere-csi-driver-webhook-secret ensures that new annotation is published in vmware-vsphere-csi-driver-webhook deployment. This, in turn, leads to webhook pods restart.