### PR TITLE
OCPBUGS-13084: disable controller hostNetwork

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -22,7 +22,6 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
-      hostNetwork: true
       serviceAccountName: vmware-vsphere-csi-driver-controller-sa
       priorityClassName: system-cluster-critical
       nodeSelector:
@@ -72,7 +71,6 @@ spec:
               value: "59"
           ports:
             - name: healthz
-              # Due to hostNetwork, this port is open on a node!
               containerPort: 10301
               protocol: TCP
           livenessProbe:


### PR DESCRIPTION
To allow use of EgressIP with controller `hostNetwork` must be disabled for controller. 

Upstream does not use `hostNetwork: true` for controller deployment: https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/fcfcc25004ed6992ef05558cf123159a96361245/manifests/vanilla/vsphere-csi-driver.yaml#L191

I've tested if changing this option does not break liveness probes and metrics (with OVN networking) and did not find any issues: 

1) Verify hostNetwork is not used:
```
oc -n openshift-cluster-csi-drivers get deployment/vmware-vsphere-csi-driver-controller -o yaml | grep hostNetwork
```

2) Verify liveness probe:
```
$ oc -n openshift-cluster-csi-drivers get pod | grep controller
vmware-vsphere-csi-driver-controller-677856cf46-7cnzc   13/13   Running   0          16m
vmware-vsphere-csi-driver-controller-677856cf46-rnl6d   13/13   Running   0          16m

$ IP=`oc -n openshift-cluster-csi-drivers get pod/vmware-vsphere-csi-driver-controller-677856cf46-7cnzc -o json | jq '.status.podIP' | tr -d '"' `

$ oc -n openshift-cluster-csi-drivers exec -it pod/vmware-vsphere-csi-driver-controller-677856cf46-7cnzc curl $IP:10301/healthz

ok
```

3) Verify metrics endpoint:
```
$ token=$(oc -n openshift-monitoring exec -ti -c prometheus prometheus-k8s-0 cat /run/secrets/kubernetes.io/serviceaccount/token)

$ oc -n openshift-monitoring exec -ti -c prometheus prometheus-k8s-0 -- curl -k -H "Authorization: Bearer $token" https://vmware-vsphere-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc:443/metrics | tail
workqueue_work_duration_seconds_bucket{name="volumes",le="9.999999999999999e-06"} 0
workqueue_work_duration_seconds_bucket{name="volumes",le="9.999999999999999e-05"} 0
workqueue_work_duration_seconds_bucket{name="volumes",le="0.001"} 0
workqueue_work_duration_seconds_bucket{name="volumes",le="0.01"} 0
workqueue_work_duration_seconds_bucket{name="volumes",le="0.1"} 0
workqueue_work_duration_seconds_bucket{name="volumes",le="1"} 0
workqueue_work_duration_seconds_bucket{name="volumes",le="10"} 0
workqueue_work_duration_seconds_bucket{name="volumes",le="+Inf"} 0
workqueue_work_duration_seconds_sum{name="volumes"} 0
workqueue_work_duration_seconds_count{name="volumes"} 0
