### PR TITLE
OCPBUGS-21826: Warn when managment state is set to values other than Managed

### DIFF
--- a/pkg/operator/vspherecontroller/vspherecontroller.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller.go
@@ -149,7 +149,7 @@ func (c *VSphereController) sync(ctx context.Context, syncContext factory.SyncCo
 	}
 
 	if opSpec.ManagementState != operatorapi.Managed {
-		klog.V(4).Infof("%s: ManagementState is %s, skipping", c.name, opSpec.ManagementState)
+		klog.Warningf("%s: ManagementState is %s, skipping", c.name, opSpec.ManagementState)
 		return nil
 	}
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OCPBUGS-21826