### PR TITLE
OCPBUGS-23342: Add dummy Progressing condition on blocked driver install

### DIFF
--- a/pkg/operator/vspherecontroller/checks/check_error.go
+++ b/pkg/operator/vspherecontroller/checks/check_error.go
@@ -38,7 +38,7 @@ type CheckAction int
 const (
 	CheckActionPass                      = iota
 	CheckActionBlockUpgrade              // Only block upgrade
-	CheckActionBlockUpgradeDriverInstall // Block voth upgrade and driver install
+	CheckActionBlockUpgradeDriverInstall // Block both upgrade and driver install
 	CheckActionBlockUpgradeOrDegrade     // Degrade if the driver is installed, block upgrade otherwise
 	CheckActionDegrade
 )

--- a/pkg/operator/vspherecontroller/vspherecontroller.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller.go
@@ -444,12 +444,35 @@ func (c *VSphereController) updateConditions(
 	lastCheckResult checks.ClusterCheckResult,
 	status *operatorapi.OperatorStatus,
 	upgradeStatus operatorapi.ConditionStatus) error {
+
+	updateFuncs := []v1helpers.UpdateStatusFunc{}
+
+	progressingConditionName := name + operatorapi.OperatorStatusTypeProgressing
+	if lastCheckResult.Action == checks.CheckActionBlockUpgradeDriverInstall {
+		// Add a dummy Progressing condition. cluster-storage-operator needs at least one *Progressing
+		// condition to be present in ClusterCSIDriver to compute overall Progressing condition of the driver,
+		// otherwise it sets Progressing=True forever.
+		// In case of CheckActionBlockUpgradeDriverInstall, this dummy condition will be the only Progressing
+		// condition that makes the whole ClusterCSIDriver Progressing=false.
+		klog.V(4).Infof("Adding %s to mark the whole ClusterCSIDriver as Progressing=False", progressingConditionName)
+		progressingCond := operatorapi.OperatorCondition{
+			Type:   progressingConditionName,
+			Status: operatorapi.ConditionFalse,
+		}
+		updateFuncs = append(updateFuncs, v1helpers.UpdateConditionFn(progressingCond))
+	} else {
+		// Remove the dummy condition, CSIControllerSet will report its own set of progressing conditions.
+		klog.V(4).Infof("Removing %s", progressingConditionName)
+		updateFuncs = append(updateFuncs, func(status *operatorapi.OperatorStatus) error {
+			v1helpers.RemoveOperatorCondition(&status.Conditions, progressingConditionName)
+			return nil
+		})
+	}
+
 	availableCnd := operatorapi.OperatorCondition{
 		Type:   name + operatorapi.OperatorStatusTypeAvailable,
 		Status: operatorapi.ConditionTrue,
 	}
-
-	updateFuncs := []v1helpers.UpdateStatusFunc{}
 
 	// we are degrading using a custom name here because, if we use name + Degraded
 	// library-go will override the condition and mark cluster un-degraded.
@@ -506,6 +529,7 @@ func (c *VSphereController) updateConditions(
 	if _, _, updateErr := v1helpers.UpdateStatus(ctx, c.operatorClient, updateFuncs...); updateErr != nil {
 		return updateErr
 	}
+
 	return nil
 }
 

--- a/pkg/operator/vspherecontroller/vspherecontroller_test.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller_test.go
@@ -244,6 +244,10 @@ func TestSync(t *testing.T) {
 					Type:   testControllerName + opv1.OperatorStatusTypeUpgradeable,
 					Status: opv1.ConditionFalse,
 				},
+				{
+					Type:   testControllerName + opv1.OperatorStatusTypeProgressing,
+					Status: opv1.ConditionFalse,
+				},
 			},
 			expectedMetrics: `vsphere_csi_driver_error{condition="install_blocked",failure_reason="existing_driver_found"} 1
 vsphere_csi_driver_error{condition="upgrade_blocked",failure_reason="existing_driver_found"} 1`,
@@ -265,6 +269,10 @@ vsphere_csi_driver_error{condition="upgrade_blocked",failure_reason="existing_dr
 				},
 				{
 					Type:   testControllerName + opv1.OperatorStatusTypeUpgradeable,
+					Status: opv1.ConditionFalse,
+				},
+				{
+					Type:   testControllerName + opv1.OperatorStatusTypeProgressing,
 					Status: opv1.ConditionFalse,
 				},
 			},


### PR DESCRIPTION
When CSI driver installation is blocked, e.g. because upstream CSI driver is installed, add a dummy `Progressing` condition 
to ClusterCSIDriver. Because without any *Progressing condition, CSO will default to `Progressing=True` and the whole storage will be `Progressing=True` forever.

@openshift/storage 