### PR TITLE
OCPBUGS-23342: Add dummy Progressing condition on blocked driver install

### DIFF
--- a/pkg/operator/vspherecontroller/checks/check_error.go
+++ b/pkg/operator/vspherecontroller/checks/check_error.go
@@ -38,7 +38,7 @@ type CheckAction int
 const (
 	CheckActionPass                      = iota
 	CheckActionBlockUpgrade              // Only block upgrade
-	CheckActionBlockUpgradeDriverInstall // Block voth upgrade and driver install
+	CheckActionBlockUpgradeDriverInstall // Block both upgrade and driver install
 	CheckActionBlockUpgradeOrDegrade     // Degrade if the driver is installed, block upgrade otherwise
 	CheckActionDegrade
 )

--- a/pkg/operator/vspherecontroller/vspherecontroller_test.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller_test.go
@@ -226,6 +226,10 @@ func TestSync(t *testing.T) {
 					Type:   testControllerName + opv1.OperatorStatusTypeUpgradeable,
 					Status: opv1.ConditionFalse,
 				},
+				{
+					Type:   testControllerName + opv1.OperatorStatusTypeProgressing,
+					Status: opv1.ConditionFalse,
+				},
 			},
 			expectedMetrics: `vsphere_csi_driver_error{condition="install_blocked",failure_reason="existing_driver_found"} 1
 vsphere_csi_driver_error{condition="upgrade_blocked",failure_reason="existing_driver_found"} 1`,
@@ -247,6 +251,10 @@ vsphere_csi_driver_error{condition="upgrade_blocked",failure_reason="existing_dr
 				},
 				{
 					Type:   testControllerName + opv1.OperatorStatusTypeUpgradeable,
+					Status: opv1.ConditionFalse,
+				},
+				{
+					Type:   testControllerName + opv1.OperatorStatusTypeProgressing,
 					Status: opv1.ConditionFalse,
 				},
 			},


### PR DESCRIPTION
Manually cherry-pick https://github.com/openshift/vmware-vsphere-csi-driver-operator/pull/191 to 4.14.

When CSI driver installation is blocked, e.g. because upstream CSI driver is installed, add a dummy Progressing condition to ClusterCSIDriver. Without any `*Progressing` condition, CSO will default to `Progressing=True`.

@openshift/storage 