### PR TITLE
OCPBUGS-27242: fix or ignore snyk errors for ocp storage repos

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,3 +4,4 @@
 exclude:
   global:
     - vendor/**
+    - pkg/operator/testlib/vcsim_framework.go


### PR DESCRIPTION
Ignore these two errors. The simulator is only used from unit test code and does not contain real credentials.

```
 ✗ [Low] Use of Hardcoded Credentials
   ID: 1bbb6426-7781-4fd7-b74a-64bc739ffc49 
   Path: pkg/operator/testlib/vcsim_framework.go, line 83 
   Info: Do not hardcode credentials in code. Found hardcoded credential used in Username.
 ✗ [Medium] Use of Hardcoded Credentials
   ID: 6420cae8-510f-4c8d-8051-d22a2c61529c 
   Path: pkg/operator/testlib/vcsim_framework.go, line 84 
   Info: Do not hardcode passwords in code. Found hardcoded saved in Password.
```

from https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/47618/rehearse-47618-pull-ci-openshift-vmware-vsphere-csi-driver-operator-master-security/1745954200828776448

/cc @openshift/storage
