### PR TITLE
OCPBUGS-26924: Enable healthcheck for node-registrar containerPort

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -96,6 +96,7 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            - --http-endpoint=:10302
             - --v=${LOG_LEVEL}
           lifecycle:
             preStop:
@@ -115,10 +116,21 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+          ports:
+            - containerPort: 10302
+              name: rhealthz
           resources:
             requests:
               memory: 50Mi
               cpu: 10m
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: rhealthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 10
+            failureThreshold: 5
         - name: csi-liveness-probe
           image: ${LIVENESS_PROBE_IMAGE}
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
This will help from crashing the container if someone runs `oc debug` accidently against it or something.

Fixes https://issues.redhat.com/browse/OCPBUGS-26924