### PR TITLE
SPLAT-1637: Initial changes for multi vcenter support.

### DIFF
--- a/assets/csi_cloud_config.ini
+++ b/assets/csi_cloud_config.ini
@@ -3,8 +3,6 @@
 [Global]
 cluster-id = "${CLUSTER_ID}"
 
-[VirtualCenter "${VCENTER}"]
-insecure-flag = "true"
-datacenters = "${DATACENTERS}"
-migration-datastore-url = "${MIGRATION_DATASTORE_URL}"
+# Populate VCenters (multi) after here
+${VCENTERS}
 

--- a/assets/csi_cloud_config_vcenters.ini
+++ b/assets/csi_cloud_config_vcenters.ini
@@ -1,6 +1,5 @@
 [VirtualCenter "${VCENTER}"]
 insecure-flag = true
 datacenters = ${DATACENTERS}
-migration-datastore-url = ${MIGRATION_DATASTORE_URL}
 password = "${PASSWORD}"
 user = "${USER}"

--- a/assets/csi_cloud_config_vcenters.ini
+++ b/assets/csi_cloud_config_vcenters.ini
@@ -1,0 +1,6 @@
+[VirtualCenter "${VCENTER}"]
+insecure-flag = true
+datacenters = ${DATACENTERS}
+migration-datastore-url = ${MIGRATION_DATASTORE_URL}
+password = "${PASSWORD}"
+user = "${USER}"

--- a/assets/rbac/csi_driver_controller_role.yaml
+++ b/assets/rbac/csi_driver_controller_role.yaml
@@ -40,7 +40,7 @@ rules:
     resources: ["triggercsifullsyncs"]
     verbs: ["create", "get", "update", "watch", "list"]
   - apiGroups: ["cns.vmware.com"]
-    resources: ["cnsvspherevolumemigrations"]
+    resources: ["cnsvolumeinfoes"]
     verbs: ["create", "get", "list", "watch", "update", "delete"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsvolumeoperationrequests"]

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/vmware/govmomi v0.39.0
 	gopkg.in/gcfg.v1 v1.2.3
 	gopkg.in/ini.v1 v1.67.0
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.30.3
 	k8s.io/apiextensions-apiserver v0.30.3
 	k8s.io/apimachinery v0.30.3
@@ -28,7 +29,7 @@ require (
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
-	github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df // indirect
+	github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230321174746-8dcc6526cfb1 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
@@ -59,7 +60,7 @@ require (
 	github.com/gorilla/websocket v1.5.1 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.21.0 // indirect
-	github.com/imdario/mergo v0.3.7 // indirect
+	github.com/imdario/mergo v0.3.15 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -110,7 +111,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiserver v0.30.3 // indirect
 	k8s.io/cloud-provider v0.30.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
-github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h1:7RFfzj4SSt6nnvCPbCqijJi1nWCd+TqAT3bYCStRC18=
-github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
+github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230321174746-8dcc6526cfb1 h1:X8MJ0fnN5FPdcGF5Ij2/OW+HgiJrRg3AfHAx1PJtIzM=
+github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230321174746-8dcc6526cfb1/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -106,8 +106,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.21.0 h1:CWyXh/jylQWp2dtiV33mY4iSSp6
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.21.0/go.mod h1:nCLIt0w3Ept2NwF8ThLmrppXsfT07oC8k0XNDxd8sVU=
 github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
 github.com/ianlancetaylor/demangle v0.0.0-20230524184225-eabc099b10ab/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
-github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
-github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/imdario/mergo v0.3.15 h1:M8XP7IuFNsqUx6VPK2P9OSmsYsI/YFaGil0uD21V3dM=
+github.com/imdario/mergo v0.3.15/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9qUBdQ=

--- a/pkg/operator/storageclasscontroller/multivcenterstorageclasscontroller.go
+++ b/pkg/operator/storageclasscontroller/multivcenterstorageclasscontroller.go
@@ -1,0 +1,91 @@
+package storageclasscontroller
+
+import (
+	"context"
+	operatorapi "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/utils"
+	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/vclib"
+	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/vspherecontroller/checks"
+	"k8s.io/klog/v2"
+	"time"
+)
+
+type MultiVCenterStorageClassController struct {
+	AbstractStorageClass
+	connPolicyNames map[string]string // Key is vcenter name, value is policy name
+}
+
+func makeMultiVCenterStorageClassController(abstract AbstractStorageClass) *MultiVCenterStorageClassController {
+	scc := MultiVCenterStorageClassController{
+		AbstractStorageClass: abstract,
+		connPolicyNames:      make(map[string]string),
+	}
+	scc.AbstractStorageClass.StorageClassSyncInterface = &scc
+	return &scc
+}
+
+func (c *MultiVCenterStorageClassController) Sync(ctx context.Context, connections []*vclib.VSphereConnection, apiDeps checks.KubeAPIInterface) error {
+	checkResultFunc := func() (checks.ClusterCheckResult, checks.ClusterCheckStatus) {
+		sc := resourceread.ReadStorageClassV1OrDie(c.manifest)
+		scState := c.scStateEvaluator.GetStorageClassState(sc.Provisioner)
+
+		// Iterate through each vcenter connection for storage policy.
+		for _, connection := range connections {
+			klog.V(4).Infof("Syncing %v", connection.Hostname)
+			policyName, syncResult := c.syncStoragePolicy(ctx, connection, apiDeps, scState)
+			if syncResult.CheckError != nil {
+				klog.Errorf("error syncing storage policy: %v", syncResult.Reason)
+				clusterCondition := "storage_class_sync_failed"
+				utils.InstallErrorMetric.WithLabelValues(string(syncResult.CheckStatus), clusterCondition).Set(1)
+				return syncResult, checks.ClusterCheckAllGood
+			}
+			klog.V(4).Infof("Synced policy %v", policyName)
+			c.connPolicyNames[connection.Hostname] = policyName
+			c.policyName = policyName // This is the global name of policy.  may need to make it more logical to not set in loop.
+		}
+
+		err := c.syncStorageClass(ctx, scState)
+		if err != nil {
+			klog.Errorf("error syncing storage class: %v", err)
+			return checks.MakeClusterDegradedError(checks.CheckStatusOpenshiftAPIError, err), checks.ClusterCheckDegrade
+		}
+		return checks.MakeClusterCheckResultPass(), checks.ClusterCheckAllGood
+	}
+
+	checkResult, overallClusterStatus := checkResultFunc()
+	return c.updateConditions(ctx, checkResult, overallClusterStatus)
+}
+
+func (c *MultiVCenterStorageClassController) syncStoragePolicy(ctx context.Context, connection *vclib.VSphereConnection, apiDeps checks.KubeAPIInterface, scState operatorapi.StorageClassStateName) (string, checks.ClusterCheckResult) {
+	// if the SC is not managed, there is no need to sync the storage policy
+	if !c.scStateEvaluator.IsManaged(scState) {
+		klog.V(2).Info("sc is not managed")
+		return "", checks.MakeClusterCheckResultPass()
+	}
+
+	// if we are running the checks after creating the policy successfully
+	// then lets run checks less frequently.
+	if !time.Now().After(c.nextCheck) && len(c.connPolicyNames[connection.Hostname]) > 0 {
+		klog.V(4).Infof("Returning without running any checks")
+		return c.connPolicyNames[connection.Hostname], checks.MakeClusterCheckResultPass()
+	}
+
+	infra := apiDeps.GetInfrastructure()
+	apiClient := c.makeStoragePolicyAPI(ctx, connection, infra)
+
+	// we expect all API calls to finish within apiTimeout or else operator might be stuck
+	tctx, cancel := context.WithTimeout(ctx, apiTimeout)
+	defer cancel()
+
+	policyName, err := apiClient.createStoragePolicy(tctx)
+
+	nextRunDelay := c.backoff.Step()
+	c.lastCheck = time.Now()
+	c.nextCheck = c.lastCheck.Add(nextRunDelay)
+
+	if err != nil {
+		return "", checks.MakeGenericVCenterAPIError(err)
+	}
+	return policyName, checks.MakeClusterCheckResultPass()
+}

--- a/pkg/operator/storageclasscontroller/storageclasscontroller.go
+++ b/pkg/operator/storageclasscontroller/storageclasscontroller.go
@@ -14,7 +14,9 @@ import (
 	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/vclib"
 	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/vspherecontroller/checks"
 
+	"github.com/openshift/api/features"
 	clustercsidriverinformer "github.com/openshift/client-go/operator/informers/externalversions/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	csiscc "github.com/openshift/library-go/pkg/operator/csi/csistorageclasscontroller"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
@@ -47,7 +49,8 @@ type StorageClassSyncInterface interface {
 	Sync(ctx context.Context, connection []*vclib.VSphereConnection, apiDeps checks.KubeAPIInterface) error
 }
 
-type StorageClassController struct {
+type AbstractStorageClass struct {
+	StorageClassSyncInterface
 	name                 string
 	targetNamespace      string
 	manifest             []byte
@@ -58,11 +61,18 @@ type StorageClassController struct {
 	makeStoragePolicyAPI func(ctx context.Context, connection *vclib.VSphereConnection, infra *v1.Infrastructure) vCenterInterface
 	scStateEvaluator     *csiscc.StorageClassStateEvaluator
 
-	connPolicyNames map[string]string // Key is vcenter name, value is policy name
-	policyName      string
-	backoff         wait.Backoff
-	nextCheck       time.Time
-	lastCheck       time.Time
+	policyName string
+	backoff    wait.Backoff
+	nextCheck  time.Time
+	lastCheck  time.Time
+}
+
+type StorageClassController struct{ AbstractStorageClass }
+
+func makeStorageClassController(abstract AbstractStorageClass) *StorageClassController {
+	scc := StorageClassController{AbstractStorageClass: abstract}
+	scc.AbstractStorageClass.StorageClassSyncInterface = &scc
+	return &scc
 }
 
 func NewStorageClassController(
@@ -74,13 +84,16 @@ func NewStorageClassController(
 	storageClassLister storagev1.StorageClassLister,
 	clusterCSIDriverInformer clustercsidriverinformer.ClusterCSIDriverInformer,
 	recorder events.Recorder,
+	featureGates featuregates.FeatureGate,
 ) StorageClassSyncInterface {
 	evaluator := csiscc.NewStorageClassStateEvaluator(
 		kubeClient,
 		clusterCSIDriverInformer.Lister(),
 		recorder,
 	)
-	c := &StorageClassController{
+
+	var c StorageClassSyncInterface
+	scc := AbstractStorageClass{
 		name:                 name,
 		targetNamespace:      targetNamespace,
 		manifest:             manifest,
@@ -92,7 +105,13 @@ func NewStorageClassController(
 		scStateEvaluator:     evaluator,
 		backoff:              defaultBackoff,
 		nextCheck:            time.Now(),
-		connPolicyNames:      make(map[string]string),
+	}
+	if featureGates.Enabled(features.FeatureGateVSphereMultiVCenters) {
+		klog.V(2).Infof("Creating multi vcenter storage class controller")
+		c = makeMultiVCenterStorageClassController(scc)
+	} else {
+		klog.V(2).Infof("Creating single vcenter storage class controller")
+		c = makeStorageClassController(scc)
 	}
 
 	return c
@@ -103,20 +122,16 @@ func (c *StorageClassController) Sync(ctx context.Context, connections []*vclib.
 		sc := resourceread.ReadStorageClassV1OrDie(c.manifest)
 		scState := c.scStateEvaluator.GetStorageClassState(sc.Provisioner)
 
-		// Iterate through each vcenter connection for storage policy.
-		for _, connection := range connections {
-			klog.V(2).Infof("Syncing %v", connection.Hostname)
-			policyName, syncResult := c.syncStoragePolicy(ctx, connection, apiDeps, scState)
-			if syncResult.CheckError != nil {
-				klog.Errorf("error syncing storage policy: %v", syncResult.Reason)
-				clusterCondition := "storage_class_sync_failed"
-				utils.InstallErrorMetric.WithLabelValues(string(syncResult.CheckStatus), clusterCondition).Set(1)
-				return syncResult, checks.ClusterCheckAllGood
-			}
-			klog.V(2).Infof("Synced policy %v", policyName)
-			c.connPolicyNames[connection.Hostname] = policyName
-			c.policyName = policyName // This is the global name of policy.  may need to make it more logical to not set in loop.
+		// This storage class controller only handles single vCenter.  It will only use the first connection (there should never be
+		// more than 1)
+		policyName, syncResult := c.syncStoragePolicy(ctx, connections[0], apiDeps, scState)
+		if syncResult.CheckError != nil {
+			klog.Errorf("error syncing storage policy: %v", syncResult.Reason)
+			clusterCondition := "storage_class_sync_failed"
+			utils.InstallErrorMetric.WithLabelValues(string(syncResult.CheckStatus), clusterCondition).Set(1)
+			return syncResult, checks.ClusterCheckAllGood
 		}
+		c.policyName = policyName
 
 		err := c.syncStorageClass(ctx, scState)
 		if err != nil {
@@ -130,18 +145,17 @@ func (c *StorageClassController) Sync(ctx context.Context, connections []*vclib.
 	return c.updateConditions(ctx, checkResult, overallClusterStatus)
 }
 
-func (c *StorageClassController) syncStoragePolicy(ctx context.Context, connection *vclib.VSphereConnection, apiDeps checks.KubeAPIInterface, scState operatorapi.StorageClassStateName) (string, checks.ClusterCheckResult) {
+func (c *AbstractStorageClass) syncStoragePolicy(ctx context.Context, connection *vclib.VSphereConnection, apiDeps checks.KubeAPIInterface, scState operatorapi.StorageClassStateName) (string, checks.ClusterCheckResult) {
 	// if the SC is not managed, there is no need to sync the storage policy
 	if !c.scStateEvaluator.IsManaged(scState) {
-		klog.V(2).Info("sc is not managed")
 		return "", checks.MakeClusterCheckResultPass()
 	}
 
 	// if we are running the checks after creating the policy successfully
 	// then lets run checks less frequently.
-	if !time.Now().After(c.nextCheck) && len(c.connPolicyNames[connection.Hostname]) > 0 {
+	if !time.Now().After(c.nextCheck) && len(c.policyName) > 0 {
 		klog.V(4).Infof("Returning without running any checks")
-		return c.connPolicyNames[connection.Hostname], checks.MakeClusterCheckResultPass()
+		return c.policyName, checks.MakeClusterCheckResultPass()
 	}
 
 	infra := apiDeps.GetInfrastructure()
@@ -163,7 +177,7 @@ func (c *StorageClassController) syncStoragePolicy(ctx context.Context, connecti
 	return policyName, checks.MakeClusterCheckResultPass()
 }
 
-func (c *StorageClassController) updateConditions(ctx context.Context, lastCheckResult checks.ClusterCheckResult, clusterStatus checks.ClusterCheckStatus) error {
+func (c *AbstractStorageClass) updateConditions(ctx context.Context, lastCheckResult checks.ClusterCheckResult, clusterStatus checks.ClusterCheckStatus) error {
 	availableCnd := operatorapi.OperatorCondition{
 		Type:   c.name + operatorapi.OperatorStatusTypeAvailable,
 		Status: operatorapi.ConditionTrue,
@@ -200,7 +214,7 @@ func (c *StorageClassController) updateConditions(ctx context.Context, lastCheck
 	return nil
 }
 
-func (c *StorageClassController) syncStorageClass(ctx context.Context, scState operatorapi.StorageClassStateName) error {
+func (c *AbstractStorageClass) syncStorageClass(ctx context.Context, scState operatorapi.StorageClassStateName) error {
 	scString := string(c.manifest)
 	pairs := []string{
 		"${STORAGE_POLICY_NAME}", c.policyName,

--- a/pkg/operator/storageclasscontroller/storageclasscontroller_test.go
+++ b/pkg/operator/storageclasscontroller/storageclasscontroller_test.go
@@ -70,6 +70,7 @@ func newStorageClassController(apiClients *utils.APIClient, storageclassfile str
 		recorder:             rc,
 		makeStoragePolicyAPI: spFunc,
 		scStateEvaluator:     evaluator,
+		connPolicyNames:      make(map[string]string),
 	}
 
 	return c
@@ -160,14 +161,15 @@ func TestSync(t *testing.T) {
 			commonApiClient := testlib.NewFakeClients(test.initialObjects, test.clusterCSIDriverObject, test.configObjects)
 
 			apiDeps := getCheckAPIDependency(commonApiClient)
-			var conn *vclib.VSphereConnection
+			var conn vclib.VSphereConnection
+			conns := []*vclib.VSphereConnection{&conn}
 			scController := newStorageClassController(commonApiClient, test.storageClass, test.StoragePolicyAPIfails)
 
 			if test.shouldPanic {
 				defer assertPanic(t)
 			}
 			// err will be nil on even on failure, need to check conditions instead
-			err := scController.Sync(context.TODO(), conn, apiDeps)
+			err := scController.Sync(context.TODO(), conns, apiDeps)
 			if err != nil {
 				t.Errorf("failed to sync controller: %+v", err)
 			}
@@ -219,12 +221,14 @@ func TestSyncMultiple(t *testing.T) {
 			commonApiClient := testlib.NewFakeClients(initialObjects, clusterCSIDriverObject, configObjects)
 			storageClass := "storageclass1.yaml"
 			apiDeps := getCheckAPIDependency(commonApiClient)
-			var conn *vclib.VSphereConnection
+			conn := vclib.VSphereConnection{
+				Hostname: "test",
+			}
 			scController := newStorageClassController(commonApiClient, storageClass, test.storagePolicySyncFails)
 			scController.backoff = defaultBackoff
 
 			// err will be nil on even on failure, need to check conditions instead
-			policyName, clusterCheckResult := scController.syncStoragePolicy(context.TODO(), conn, apiDeps, opv1.ManagedStorageClass)
+			policyName, clusterCheckResult := scController.syncStoragePolicy(context.TODO(), &conn, apiDeps, opv1.ManagedStorageClass)
 			scController.policyName = policyName
 
 			if test.expectError {
@@ -239,12 +243,8 @@ func TestSyncMultiple(t *testing.T) {
 					t.Errorf("Expected no error got: %v", clusterCheckResult.CheckError)
 				}
 			}
-			// setting this to nil will cause the test that uses makeStoragePolicyAPI call to panic
-			if !test.storagePolicySyncFails {
-				scController.makeStoragePolicyAPI = nil
-			}
 
-			policyName, clusterCheckResult = scController.syncStoragePolicy(context.TODO(), conn, apiDeps, opv1.ManagedStorageClass)
+			policyName, clusterCheckResult = scController.syncStoragePolicy(context.TODO(), &conn, apiDeps, opv1.ManagedStorageClass)
 			if test.expectError {
 				if clusterCheckResult.CheckError == nil {
 					t.Errorf("Expected error got none")

--- a/pkg/operator/storageclasscontroller/storageclasscontroller_test.go
+++ b/pkg/operator/storageclasscontroller/storageclasscontroller_test.go
@@ -61,16 +61,17 @@ func newStorageClassController(apiClients *utils.APIClient, storageclassfile str
 	)
 
 	c := &StorageClassController{
-		name:                 testScControllerName,
-		targetNamespace:      testScControllerNamespace,
-		manifest:             scBytes,
-		kubeClient:           apiClients.KubeClient,
-		operatorClient:       apiClients.OperatorClient,
-		storageClassLister:   apiClients.KubeInformers.InformersFor("").Storage().V1().StorageClasses().Lister(),
-		recorder:             rc,
-		makeStoragePolicyAPI: spFunc,
-		scStateEvaluator:     evaluator,
-		connPolicyNames:      make(map[string]string),
+		AbstractStorageClass{
+			name:                 testScControllerName,
+			targetNamespace:      testScControllerNamespace,
+			manifest:             scBytes,
+			kubeClient:           apiClients.KubeClient,
+			operatorClient:       apiClients.OperatorClient,
+			storageClassLister:   apiClients.KubeInformers.InformersFor("").Storage().V1().StorageClasses().Lister(),
+			recorder:             rc,
+			makeStoragePolicyAPI: spFunc,
+			scStateEvaluator:     evaluator,
+		},
 	}
 
 	return c

--- a/pkg/operator/testlib/multiple_dc.yaml
+++ b/pkg/operator/testlib/multiple_dc.yaml
@@ -1,0 +1,15 @@
+global:
+  insecureFlag: true
+  secretName: vsphere-creds
+  secretNamespace: kube-system
+vcenter:
+  foobar.lan:
+    server: foobar.lan
+    port: 443
+    insecureFlag: true
+    datacenters:
+      - Datacentera
+      - DatacenterB
+labels:
+  zone: openshift-zone
+  region: openshift-region

--- a/pkg/operator/testlib/multiple_vc.yaml
+++ b/pkg/operator/testlib/multiple_vc.yaml
@@ -1,0 +1,20 @@
+global:
+  insecureFlag: true
+  secretName: vsphere-creds
+  secretNamespace: kube-system
+vcenter:
+  foobar.lan:
+    server: foobar.lan
+    port: 443
+    insecureFlag: true
+    datacenters:
+      - Datacenter
+  foobaz.lan:
+    server: foobaz.lan
+    port: 443
+    insecureFlag: true
+    datacenters:
+      - Datacenterb
+labels:
+  zone: openshift-zone
+  region: openshift-region

--- a/pkg/operator/utils/topology.go
+++ b/pkg/operator/utils/topology.go
@@ -1,12 +1,9 @@
 package utils
 
 import (
-	"fmt"
-
 	cfgv1 "github.com/openshift/api/config/v1"
 	opv1 "github.com/openshift/api/operator/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	vsphere "k8s.io/cloud-provider-vsphere/pkg/common/config"
 )
 
 const (
@@ -42,21 +39,6 @@ func GetTopologyCategories(clusterCSIDriver *opv1.ClusterCSIDriver, infra *cfgv1
 		return infraCategories
 	}
 	return GetCSIDriverTopologyCategories(clusterCSIDriver)
-}
-
-func GetVCenters(config *vsphere.Config, multiVCenterEnabled bool) ([]string, error) {
-	if len(config.VirtualCenter) > 1 && !multiVCenterEnabled {
-		return nil, fmt.Errorf("the multi vcenter cloud config must define a single VirtualCenter")
-	} else if len(config.VirtualCenter) == 0 {
-		return nil, fmt.Errorf("cloud config must define at lease a single VirtualCenter")
-	}
-
-	var vCenters []string
-	for _, vcenter := range config.VirtualCenter {
-		vCenters = append(vCenters, vcenter.VCenterIP)
-	}
-
-	return vCenters, nil
 }
 
 func UpdateMetrics(infra *cfgv1.Infrastructure, clusterCSIDriver *opv1.ClusterCSIDriver) {

--- a/pkg/operator/vclib/connection.go
+++ b/pkg/operator/vclib/connection.go
@@ -4,17 +4,22 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/openshift/api/features"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/version"
 	"github.com/vmware/govmomi/cns"
 	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
-	"k8s.io/legacy-cloud-providers/vsphere"
+	vsphere "k8s.io/cloud-provider-vsphere/pkg/common/config"
+	legacy "k8s.io/legacy-cloud-providers/vsphere"
 
 	"github.com/vmware/govmomi"
+	"gopkg.in/gcfg.v1"
 	"k8s.io/klog/v2"
 )
 
@@ -28,7 +33,76 @@ type VSphereConnection struct {
 	Hostname   string
 	Port       string
 	Insecure   bool
-	Config     *vsphere.VSphereConfig
+	Config     *VSphereConfig
+}
+
+// VSphereConfig contains configuration for cloud provider.  It wraps the legacy version and the newer upstream version
+// with yaml support
+type VSphereConfig struct {
+	Config       *vsphere.Config
+	LegacyConfig *legacy.VSphereConfig
+}
+
+// LoadConfig load the desired config into this config object.
+func (c *VSphereConfig) LoadConfig(data string) error {
+	var err error
+	c.Config, err = vsphere.ReadConfig([]byte(data))
+	if err != nil {
+		return err
+	}
+
+	// Load legacy if cfgString is not yaml.  May be needed in areas that require legacy logic.
+	lCfg := &legacy.VSphereConfig{}
+	err = gcfg.ReadStringInto(lCfg, data)
+	if err != nil {
+		// For now, we can just log an info so that we know.
+		klog.V(2).Info("Unable to load cloud config as legacy ini.")
+		return nil
+	}
+
+	c.LegacyConfig = lCfg
+	return nil
+}
+
+// GetVCenterHostname get the vcenter's hostname.
+func (c *VSphereConfig) GetVCenterHostname(vcenter string) string {
+	return c.Config.VirtualCenter[vcenter].VCenterIP
+}
+
+// IsInsecure returns true if the vcenter is configured to have an insecure connection.
+func (c *VSphereConfig) IsInsecure(vcenter string) bool {
+	return c.Config.VirtualCenter[vcenter].InsecureFlag
+}
+
+// GetDatacenters gets the datacenters.  Falls back to legacy style ini lookup if vcenter not found in primary config.
+func (c *VSphereConfig) GetDatacenters(vcenter string) ([]string, error) {
+	var datacenters []string
+	if c.Config.VirtualCenter[vcenter] != nil {
+		datacenters = strings.Split(c.Config.VirtualCenter[vcenter].Datacenters, ",")
+	} else {
+		// If here, then legacy config may be in use.
+		datacenters = []string{c.LegacyConfig.Workspace.Datacenter}
+	}
+	logrus.Infof("Gathered the following data centers: %v", datacenters)
+	return datacenters, nil
+}
+
+// GetWorkspaceDatacenter get the legacy datacenter from workspace config.
+func (c *VSphereConfig) GetWorkspaceDatacenter() string {
+	return c.LegacyConfig.Workspace.Datacenter
+}
+
+// GetDefaultDatastore get the default datastore.  This is primarily used with legacy ini config.
+func (c *VSphereConfig) GetDefaultDatastore() string {
+	return c.LegacyConfig.Workspace.DefaultDatastore
+}
+
+// ValidateConfig validates if current loaded config is valid.
+func (c *VSphereConfig) ValidateConfig(featureGates featuregates.FeatureGate) error {
+	if len(c.Config.VirtualCenter) > 1 && !featureGates.Enabled(features.FeatureGateVSphereMultiVCenters) {
+		return fmt.Errorf("cloud config must define a single VirtualCenter")
+	}
+	return nil
 }
 
 const apiTimeout = 10 * time.Minute
@@ -37,13 +111,13 @@ var (
 	clientLock sync.Mutex
 )
 
-func NewVSphereConnection(username, password string, cfg *vsphere.VSphereConfig) *VSphereConnection {
+func NewVSphereConnection(username, password, vcenter string, cfg *VSphereConfig) *VSphereConnection {
 	return &VSphereConnection{
 		Username: username,
 		Password: password,
 		Config:   cfg,
-		Hostname: cfg.Workspace.VCenterIP,
-		Insecure: cfg.Global.InsecureFlag,
+		Hostname: cfg.GetVCenterHostname(vcenter),
+		Insecure: cfg.IsInsecure(vcenter),
 	}
 }
 
@@ -148,7 +222,7 @@ func (connection *VSphereConnection) VimClient() *vim25.Client {
 // Return default datacenter configured in Config
 // TODO: Do we need to setup and handle multiple datacenters?
 func (connection *VSphereConnection) DefaultDatacenter() string {
-	return connection.Config.Workspace.Datacenter
+	return connection.Config.GetWorkspaceDatacenter()
 }
 
 func (connection *VSphereConnection) CnsClient() *cns.Client {

--- a/pkg/operator/vclib/connection.go
+++ b/pkg/operator/vclib/connection.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/api/features"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/version"
+	"github.com/openshift/vmware-vsphere-csi-driver-operator/third_party/cloud-provider-vsphere/pkg/common/config"
 	"github.com/vmware/govmomi/cns"
 	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vim25"
@@ -44,14 +45,14 @@ type VSphereConnection struct {
 // VSphereConfig contains configuration for cloud provider.  It wraps the legacy version and the newer upstream version
 // with yaml support
 type VSphereConfig struct {
-	Config       *vsphere.Config
+	Config       *config.Config
 	LegacyConfig *legacy.VSphereConfig
 }
 
 // LoadConfig load the desired config into this config object.
 func (c *VSphereConfig) LoadConfig(data string) error {
 	var err error
-	c.Config, err = vsphere.ReadConfig([]byte(data))
+	c.Config, err = config.ReadConfig([]byte(data))
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/vspherecontroller/checks/interface.go
+++ b/pkg/operator/vspherecontroller/checks/interface.go
@@ -7,17 +7,14 @@ import (
 )
 
 type CheckArgs struct {
-	vmConnection        []*check.VSphereConnection
-	apiClient           KubeAPIInterface
-	featureGates        featuregates.FeatureGate
-	multiVCenterEnabled bool
+	vmConnection []*check.VSphereConnection
+	apiClient    KubeAPIInterface
 }
 
 func NewCheckArgs(connection []*check.VSphereConnection, apiClient KubeAPIInterface, gates featuregates.FeatureGate) CheckArgs {
 	return CheckArgs{
 		vmConnection: connection,
 		apiClient:    apiClient,
-		featureGates: gates,
 	}
 }
 

--- a/pkg/operator/vspherecontroller/checks/interface.go
+++ b/pkg/operator/vspherecontroller/checks/interface.go
@@ -2,18 +2,22 @@ package checks
 
 import (
 	"context"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	check "github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/vclib"
 )
 
 type CheckArgs struct {
-	vmConnection *check.VSphereConnection
-	apiClient    KubeAPIInterface
+	vmConnection        []*check.VSphereConnection
+	apiClient           KubeAPIInterface
+	featureGates        featuregates.FeatureGate
+	multiVCenterEnabled bool
 }
 
-func NewCheckArgs(connection *check.VSphereConnection, apiClient KubeAPIInterface) CheckArgs {
+func NewCheckArgs(connection []*check.VSphereConnection, apiClient KubeAPIInterface, gates featuregates.FeatureGate) CheckArgs {
 	return CheckArgs{
 		vmConnection: connection,
 		apiClient:    apiClient,
+		featureGates: gates,
 	}
 }
 

--- a/pkg/operator/vspherecontroller/config.go
+++ b/pkg/operator/vspherecontroller/config.go
@@ -19,7 +19,7 @@ type iniConfig struct {
 func newINIConfig(config string) (*iniConfig, error) {
 	// We ignore inline comments when reading the INI file
 	// because passwords may contain comment symbols (# and ;)
-	options := iniv1.LoadOptions{IgnoreInlineComment: true}
+	options := iniv1.LoadOptions{IgnoreInlineComment: true, PreserveSurroundedQuote: true}
 	csiConfig, err := iniv1.LoadSources(options, []byte(config))
 	if err != nil {
 		return nil, fmt.Errorf("error loading ini file: %v", err)

--- a/pkg/operator/vspherecontroller/config_test.go
+++ b/pkg/operator/vspherecontroller/config_test.go
@@ -42,8 +42,8 @@ password   = "password123"`,
 			expectedError: false,
 			expectedString: `[Global]
 cluster-id = 1234
-user       = user1
-password   = password123`,
+user       = "user1"
+password   = "password123"`,
 		},
 		{
 			name: "Valid config with inline comments",

--- a/pkg/operator/vspherecontroller/driver_starter_test.go
+++ b/pkg/operator/vspherecontroller/driver_starter_test.go
@@ -24,9 +24,21 @@ func TestGetvCenterName(t *testing.T) {
 			expectedVCenterName: "localhost",
 		},
 		{
+			name:                "when infra object does not have vcenter YAML",
+			infra:               testlib.GetInfraObject(),
+			configMap:           testlib.GetNewConfigMap(),
+			expectedVCenterName: "localhost",
+		},
+		{
 			name:                "when infra object does have vcenter",
 			infra:               testlib.GetSingleFailureDomainInfra(),
 			configMap:           testlib.GetConfigMap(),
+			expectedVCenterName: "vcenter.home.lan",
+		},
+		{
+			name:                "when infra object does have vcenter YAML",
+			infra:               testlib.GetSingleFailureDomainInfra(),
+			configMap:           testlib.GetNewConfigMap(),
 			expectedVCenterName: "vcenter.home.lan",
 		},
 	}

--- a/pkg/operator/vspherecontroller/vspherecontroller_test.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller_test.go
@@ -7,8 +7,11 @@ import (
 	"testing"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/features"
 	opv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/vmware-vsphere-csi-driver-operator/assets"
 	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/testlib"
@@ -27,6 +30,11 @@ const (
 )
 
 func newVsphereController(apiClients *utils.APIClient) *VSphereController {
+	gates := featuregates.NewFeatureGate([]configv1.FeatureGateName{"SomeEnabledFeatureGate"}, []configv1.FeatureGateName{"SomeDisabledFeatureGate", features.FeatureGateVSphereMultiVCenters})
+	return newVsphereControllerWithGates(apiClients, gates)
+}
+
+func newVsphereControllerWithGates(apiClients *utils.APIClient, gates featuregates.FeatureGate) *VSphereController {
 	kubeInformers := apiClients.KubeInformers
 	ocpConfigInformer := apiClients.ConfigInformers
 	configMapInformer := kubeInformers.InformersFor(cloudConfigNamespace).Core().V1().ConfigMaps()
@@ -60,6 +68,7 @@ func newVsphereController(apiClients *utils.APIClient) *VSphereController {
 		eventRecorder:          rc,
 		vSphereChecker:         newVSphereEnvironmentChecker(),
 		infraLister:            infraInformer.Lister(),
+		featureGates:           gates,
 	}
 	c.controllers = []conditionalController{}
 	c.storageClassController = &dummyStorageClassController{syncCalled: 0}
@@ -70,7 +79,7 @@ type dummyStorageClassController struct {
 	syncCalled int
 }
 
-func (c *dummyStorageClassController) Sync(ctx context.Context, connection *vclib.VSphereConnection, apiDeps checks.KubeAPIInterface) error {
+func (c *dummyStorageClassController) Sync(ctx context.Context, connection []*vclib.VSphereConnection, apiDeps checks.KubeAPIInterface) error {
 	c.syncCalled += 1
 	return nil
 }
@@ -88,7 +97,7 @@ func TestSync(t *testing.T) {
 		initialErrorMetricValue      float64
 		initialErrorMetricLabels     map[string]string
 		skipCheck                    bool
-		configObjects                runtime.Object
+		infra                        *configv1.Infrastructure
 		vcenterVersion               string
 		hostVersion                  string
 		startingNodeHardwareVersions []string
@@ -107,7 +116,28 @@ func TestSync(t *testing.T) {
 			hostVersion:                  "7.0.2",
 			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
 			initialObjects:               []runtime.Object{testlib.GetConfigMap(), testlib.GetSecret()},
-			configObjects:                runtime.Object(testlib.GetInfraObject()),
+			infra:                        testlib.GetInfraObject(),
+			expectedConditions: []opv1.OperatorCondition{
+				{
+					Type:   testControllerName + opv1.OperatorStatusTypeUpgradeable,
+					Status: opv1.ConditionTrue,
+				},
+				{
+					Type:   "VMwareVSphereOperatorCheck" + opv1.OperatorStatusTypeDegraded,
+					Status: opv1.ConditionFalse,
+				},
+			},
+			operandStarted:      true,
+			storageClassCreated: true,
+		},
+		{
+			name:                         "when all configuration is right YAML",
+			clusterCSIDriverObject:       testlib.MakeFakeDriverInstance(),
+			vcenterVersion:               "7.0.2",
+			hostVersion:                  "7.0.2",
+			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
+			initialObjects:               []runtime.Object{testlib.GetNewConfigMap(), testlib.GetSecret()},
+			infra:                        testlib.GetInfraObject(),
 			expectedConditions: []opv1.OperatorCondition{
 				{
 					Type:   testControllerName + opv1.OperatorStatusTypeUpgradeable,
@@ -128,7 +158,34 @@ func TestSync(t *testing.T) {
 			hostVersion:                  "7.0.2",
 			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
 			initialObjects:               []runtime.Object{testlib.GetConfigMap(), testlib.GetSecret()},
-			configObjects:                runtime.Object(testlib.GetInfraObject()),
+			infra:                        testlib.GetInfraObject(),
+			failVCenterConnection:        true,
+			expectedConditions: []opv1.OperatorCondition{
+				{
+					Type:   testControllerName + opv1.OperatorStatusTypeUpgradeable,
+					Status: opv1.ConditionUnknown,
+				},
+				{
+					Type:   testControllerName + "Disabled",
+					Status: opv1.ConditionTrue,
+				},
+				{
+					Type:   "VMwareVSphereOperatorCheck" + opv1.OperatorStatusTypeDegraded,
+					Status: opv1.ConditionFalse,
+				},
+			},
+			expectedMetrics:     `vsphere_csi_driver_error{condition="upgrade_unknown",failure_reason="vsphere_connection_failed"} 1`,
+			operandStarted:      false,
+			storageClassCreated: false,
+		},
+		{
+			name:                         "when we can't connect to vcenter YAML",
+			clusterCSIDriverObject:       testlib.MakeFakeDriverInstance(),
+			vcenterVersion:               "7.0.2",
+			hostVersion:                  "7.0.2",
+			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
+			initialObjects:               []runtime.Object{testlib.GetNewConfigMap(), testlib.GetSecret()},
+			infra:                        testlib.GetInfraObject(),
 			failVCenterConnection:        true,
 			expectedConditions: []opv1.OperatorCondition{
 				{
@@ -155,7 +212,29 @@ func TestSync(t *testing.T) {
 			hostVersion:                  "7.0.2",
 			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
 			initialObjects:               []runtime.Object{testlib.GetConfigMap(), testlib.GetSecret(), testlib.GetCSIDriver(true /*withOCPAnnotation*/)},
-			configObjects:                runtime.Object(testlib.GetInfraObject()),
+			infra:                        testlib.GetInfraObject(),
+			failVCenterConnection:        true,
+			expectedConditions: []opv1.OperatorCondition{
+				{
+					Type:   "VMwareVSphereOperatorCheck" + opv1.OperatorStatusTypeDegraded,
+					Status: opv1.ConditionTrue,
+				},
+				{
+					Type:   testControllerName + opv1.OperatorStatusTypeUpgradeable,
+					Status: opv1.ConditionFalse,
+				},
+			},
+			operandStarted:      true,
+			storageClassCreated: false,
+		},
+		{
+			name:                         "when we can't connect to vcenter but CSI driver was installed previously, degrade cluster YAML",
+			clusterCSIDriverObject:       testlib.MakeFakeDriverInstance(),
+			vcenterVersion:               "7.0.2",
+			hostVersion:                  "7.0.2",
+			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
+			initialObjects:               []runtime.Object{testlib.GetNewConfigMap(), testlib.GetSecret(), testlib.GetCSIDriver(true /*withOCPAnnotation*/)},
+			infra:                        testlib.GetInfraObject(),
 			failVCenterConnection:        true,
 			expectedConditions: []opv1.OperatorCondition{
 				{
@@ -176,7 +255,27 @@ func TestSync(t *testing.T) {
 			hostVersion:                  "7.0.2",
 			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
 			initialObjects:               []runtime.Object{testlib.GetConfigMap(), testlib.GetSecret()},
-			configObjects:                runtime.Object(testlib.GetInfraObject()),
+			infra:                        testlib.GetInfraObject(),
+			expectedConditions: []opv1.OperatorCondition{
+				{
+					Type:   testControllerName + opv1.OperatorStatusTypeUpgradeable,
+					Status: opv1.ConditionFalse,
+				},
+				{
+					Type:   "VMwareVSphereOperatorCheck" + opv1.OperatorStatusTypeDegraded,
+					Status: opv1.ConditionFalse,
+				},
+			},
+			operandStarted:      true,
+			storageClassCreated: true,
+		},
+		{
+			name:                         "when vcenter version is older, block upgrades YAML",
+			clusterCSIDriverObject:       testlib.MakeFakeDriverInstance(),
+			hostVersion:                  "7.0.2",
+			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
+			initialObjects:               []runtime.Object{testlib.GetNewConfigMap(), testlib.GetSecret()},
+			infra:                        testlib.GetInfraObject(),
 			expectedConditions: []opv1.OperatorCondition{
 				{
 					Type:   testControllerName + opv1.OperatorStatusTypeUpgradeable,
@@ -197,7 +296,29 @@ func TestSync(t *testing.T) {
 			hostVersion:                  "7.0.1",
 			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
 			initialObjects:               []runtime.Object{testlib.GetConfigMap(), testlib.GetSecret()},
-			configObjects:                runtime.Object(testlib.GetInfraObject()),
+			infra:                        testlib.GetInfraObject(),
+			expectedConditions: []opv1.OperatorCondition{
+				{
+					Type:   testControllerName + opv1.OperatorStatusTypeUpgradeable,
+					Status: opv1.ConditionFalse,
+				},
+				{
+					Type:   "VMwareVSphereOperatorCheck" + opv1.OperatorStatusTypeDegraded,
+					Status: opv1.ConditionFalse,
+				},
+			},
+			expectedMetrics:     `vsphere_csi_driver_error{condition="upgrade_blocked",failure_reason="check_deprecated_esxi_version"} 1`,
+			operandStarted:      true,
+			storageClassCreated: true,
+		},
+		{
+			name:                         "when host version is older, block upgrades YAML",
+			clusterCSIDriverObject:       testlib.MakeFakeDriverInstance(),
+			vcenterVersion:               "7.0.2",
+			hostVersion:                  "7.0.1",
+			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
+			initialObjects:               []runtime.Object{testlib.GetNewConfigMap(), testlib.GetSecret()},
+			infra:                        testlib.GetInfraObject(),
 			expectedConditions: []opv1.OperatorCondition{
 				{
 					Type:   testControllerName + opv1.OperatorStatusTypeUpgradeable,
@@ -218,7 +339,27 @@ func TestSync(t *testing.T) {
 			hostVersion:                  "7.0.2",
 			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
 			initialObjects:               []runtime.Object{testlib.GetConfigMap(), testlib.GetSecret(), testlib.GetCSIDriver(true)},
-			configObjects:                runtime.Object(testlib.GetInfraObject()),
+			infra:                        testlib.GetInfraObject(),
+			expectedConditions: []opv1.OperatorCondition{
+				{
+					Type:   "VMwareVSphereOperatorCheck" + opv1.OperatorStatusTypeDegraded,
+					Status: opv1.ConditionTrue,
+				},
+				{
+					Type:   testControllerName + opv1.OperatorStatusTypeUpgradeable,
+					Status: opv1.ConditionFalse,
+				},
+			},
+			storageClassCreated: false,
+			operandStarted:      true,
+		},
+		{
+			name:                         "when vcenter version is older but csi driver exists, degrade cluster YAML",
+			clusterCSIDriverObject:       testlib.MakeFakeDriverInstance(),
+			hostVersion:                  "7.0.2",
+			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
+			initialObjects:               []runtime.Object{testlib.GetNewConfigMap(), testlib.GetSecret(), testlib.GetCSIDriver(true)},
+			infra:                        testlib.GetInfraObject(),
 			expectedConditions: []opv1.OperatorCondition{
 				{
 					Type:   "VMwareVSphereOperatorCheck" + opv1.OperatorStatusTypeDegraded,
@@ -239,7 +380,34 @@ func TestSync(t *testing.T) {
 			hostVersion:                  "7.0.2",
 			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
 			initialObjects:               []runtime.Object{testlib.GetConfigMap(), testlib.GetSecret(), testlib.GetCSIDriver(false)},
-			configObjects:                runtime.Object(testlib.GetInfraObject()),
+			infra:                        testlib.GetInfraObject(),
+			expectedConditions: []opv1.OperatorCondition{
+				{
+					Type:   testControllerName + opv1.OperatorStatusTypeUpgradeable,
+					Status: opv1.ConditionFalse,
+				},
+				{
+					Type:   testControllerName + "Disabled",
+					Status: opv1.ConditionTrue,
+				},
+				{
+					Type:   "VMwareVSphereOperatorCheck" + opv1.OperatorStatusTypeDegraded,
+					Status: opv1.ConditionFalse,
+				},
+			},
+			expectedMetrics: `vsphere_csi_driver_error{condition="install_blocked",failure_reason="existing_driver_found"} 1
+vsphere_csi_driver_error{condition="upgrade_blocked",failure_reason="existing_driver_found"} 1`,
+			operandStarted:      false,
+			storageClassCreated: false,
+		},
+		{
+			name:                         "when all configuration is right, but an existing upstream CSI driver exists YAML",
+			clusterCSIDriverObject:       testlib.MakeFakeDriverInstance(),
+			vcenterVersion:               "7.0.2",
+			hostVersion:                  "7.0.2",
+			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
+			initialObjects:               []runtime.Object{testlib.GetNewConfigMap(), testlib.GetSecret(), testlib.GetCSIDriver(false)},
+			infra:                        testlib.GetInfraObject(),
 			expectedConditions: []opv1.OperatorCondition{
 				{
 					Type:   testControllerName + opv1.OperatorStatusTypeUpgradeable,
@@ -266,7 +434,34 @@ vsphere_csi_driver_error{condition="upgrade_blocked",failure_reason="existing_dr
 			hostVersion:                  "7.0.2",
 			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
 			initialObjects:               []runtime.Object{testlib.GetConfigMap(), testlib.GetSecret(), testlib.GetCSINode()},
-			configObjects:                runtime.Object(testlib.GetInfraObject()),
+			infra:                        testlib.GetInfraObject(),
+			expectedConditions: []opv1.OperatorCondition{
+				{
+					Type:   testControllerName + opv1.OperatorStatusTypeUpgradeable,
+					Status: opv1.ConditionFalse,
+				},
+				{
+					Type:   testControllerName + "Disabled",
+					Status: opv1.ConditionTrue,
+				},
+				{
+					Type:   "VMwareVSphereOperatorCheck" + opv1.OperatorStatusTypeDegraded,
+					Status: opv1.ConditionFalse,
+				},
+			},
+			expectedMetrics: `vsphere_csi_driver_error{condition="install_blocked",failure_reason="existing_driver_found"} 1
+vsphere_csi_driver_error{condition="upgrade_blocked",failure_reason="existing_driver_found"} 1`,
+			operandStarted:      false,
+			storageClassCreated: false,
+		},
+		{
+			name:                         "when all configuration is right, but an existing upstream CSI node object exists YAML",
+			clusterCSIDriverObject:       testlib.MakeFakeDriverInstance(),
+			vcenterVersion:               "7.0.2",
+			hostVersion:                  "7.0.2",
+			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
+			initialObjects:               []runtime.Object{testlib.GetNewConfigMap(), testlib.GetSecret(), testlib.GetCSINode()},
+			infra:                        testlib.GetInfraObject(),
 			expectedConditions: []opv1.OperatorCondition{
 				{
 					Type:   testControllerName + opv1.OperatorStatusTypeUpgradeable,
@@ -294,7 +489,29 @@ vsphere_csi_driver_error{condition="upgrade_blocked",failure_reason="existing_dr
 			hostVersion:                  "7.0.2",
 			startingNodeHardwareVersions: []string{"vmx-13", "vmx-15"},
 			finalNodeHardwareVersions:    []string{"vmx-15", "vmx-15"},
-			configObjects:                runtime.Object(testlib.GetInfraObject()),
+			infra:                        testlib.GetInfraObject(),
+			expectedConditions: []opv1.OperatorCondition{
+				{
+					Type:   testControllerName + opv1.OperatorStatusTypeUpgradeable,
+					Status: opv1.ConditionTrue,
+				},
+				{
+					Type:   "VMwareVSphereOperatorCheck" + opv1.OperatorStatusTypeDegraded,
+					Status: opv1.ConditionFalse,
+				},
+			},
+			operandStarted:      true,
+			storageClassCreated: true,
+		},
+		{
+			name:                         "when node hw-version was old first and got upgraded YAML",
+			clusterCSIDriverObject:       testlib.MakeFakeDriverInstance(),
+			initialObjects:               []runtime.Object{testlib.GetNewConfigMap(), testlib.GetSecret()},
+			vcenterVersion:               "7.0.2",
+			hostVersion:                  "7.0.2",
+			startingNodeHardwareVersions: []string{"vmx-13", "vmx-15"},
+			finalNodeHardwareVersions:    []string{"vmx-15", "vmx-15"},
+			infra:                        testlib.GetInfraObject(),
 			expectedConditions: []opv1.OperatorCondition{
 				{
 					Type:   testControllerName + opv1.OperatorStatusTypeUpgradeable,
@@ -317,7 +534,21 @@ vsphere_csi_driver_error{condition="upgrade_blocked",failure_reason="existing_dr
 			initialErrorMetricLabels:     map[string]string{"condition": "install_blocked", "failure_reason": "existing_driver_found"},
 			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
 			vcenterVersion:               "7.0.2",
-			configObjects:                runtime.Object(testlib.GetInfraObject()),
+			infra:                        testlib.GetInfraObject(),
+			operandStarted:               false,
+			// The metrics is not reset when no checks actually run.
+			expectedMetrics: `vsphere_csi_driver_error{condition="install_blocked",failure_reason="existing_driver_found"} 1`,
+		},
+		{
+			name:                         "sync before the next recheck interval YAML",
+			clusterCSIDriverObject:       testlib.MakeFakeDriverInstance(),
+			initialObjects:               []runtime.Object{testlib.GetNewConfigMap(), testlib.GetSecret()},
+			skipCheck:                    true,
+			initialErrorMetricValue:      1,
+			initialErrorMetricLabels:     map[string]string{"condition": "install_blocked", "failure_reason": "existing_driver_found"},
+			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
+			vcenterVersion:               "7.0.2",
+			infra:                        testlib.GetInfraObject(),
 			operandStarted:               false,
 			// The metrics is not reset when no checks actually run.
 			expectedMetrics: `vsphere_csi_driver_error{condition="install_blocked",failure_reason="existing_driver_found"} 1`,
@@ -329,7 +560,28 @@ vsphere_csi_driver_error{condition="upgrade_blocked",failure_reason="existing_dr
 			vcenterVersion:               "7.0.1", // Minimum for upgrade is 7.0.2
 			hostVersion:                  "7.0.2",
 			initialObjects:               []runtime.Object{testlib.GetConfigMap(), testlib.GetSecret(), testlib.GetCSIDriver(true)},
-			configObjects:                runtime.Object(testlib.GetInfraObject()),
+			infra:                        testlib.GetInfraObject(),
+			expectedConditions: []opv1.OperatorCondition{
+				{
+					Type:   testControllerName + opv1.OperatorStatusTypeUpgradeable,
+					Status: opv1.ConditionFalse,
+				},
+				{
+					Type:   "VMwareVSphereOperatorCheck" + opv1.OperatorStatusTypeDegraded,
+					Status: opv1.ConditionFalse,
+				},
+			},
+			operandStarted:      true,
+			storageClassCreated: true,
+		},
+		{
+			name:                         "when vcenter version is 7.0.1 and csi driver exists, mark upgradeable: false YAML",
+			clusterCSIDriverObject:       testlib.MakeFakeDriverInstance(),
+			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
+			vcenterVersion:               "7.0.1", // Minimum for upgrade is 7.0.2
+			hostVersion:                  "7.0.2",
+			initialObjects:               []runtime.Object{testlib.GetNewConfigMap(), testlib.GetSecret(), testlib.GetCSIDriver(true)},
+			infra:                        testlib.GetInfraObject(),
 			expectedConditions: []opv1.OperatorCondition{
 				{
 					Type:   testControllerName + opv1.OperatorStatusTypeUpgradeable,
@@ -350,7 +602,28 @@ vsphere_csi_driver_error{condition="upgrade_blocked",failure_reason="existing_dr
 			vcenterVersion:               "7.0.2",
 			hostVersion:                  "7.0.1", // Minimum for upgrade is 7.0.2
 			initialObjects:               []runtime.Object{testlib.GetConfigMap(), testlib.GetSecret(), testlib.GetCSIDriver(true)},
-			configObjects:                runtime.Object(testlib.GetInfraObject()),
+			infra:                        testlib.GetInfraObject(),
+			expectedConditions: []opv1.OperatorCondition{
+				{
+					Type:   testControllerName + opv1.OperatorStatusTypeUpgradeable,
+					Status: opv1.ConditionFalse,
+				},
+				{
+					Type:   "VMwareVSphereOperatorCheck" + opv1.OperatorStatusTypeDegraded,
+					Status: opv1.ConditionFalse,
+				},
+			},
+			operandStarted:      true,
+			storageClassCreated: true,
+		},
+		{
+			name:                         "when host version is 7.0.1 and csi driver exists, mark upgradeable: false YAML",
+			clusterCSIDriverObject:       testlib.MakeFakeDriverInstance(),
+			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
+			vcenterVersion:               "7.0.2",
+			hostVersion:                  "7.0.1", // Minimum for upgrade is 7.0.2
+			initialObjects:               []runtime.Object{testlib.GetNewConfigMap(), testlib.GetSecret(), testlib.GetCSIDriver(true)},
+			infra:                        testlib.GetInfraObject(),
 			expectedConditions: []opv1.OperatorCondition{
 				{
 					Type:   testControllerName + opv1.OperatorStatusTypeUpgradeable,
@@ -380,7 +653,7 @@ vsphere_csi_driver_error{condition="upgrade_blocked",failure_reason="existing_dr
 			for _, node := range nodes {
 				test.initialObjects = append(test.initialObjects, runtime.Object(node))
 			}
-			commonApiClient := testlib.NewFakeClients(test.initialObjects, test.clusterCSIDriverObject, test.configObjects)
+			commonApiClient := testlib.NewFakeClients(test.initialObjects, test.clusterCSIDriverObject, runtime.Object(test.infra))
 			clusterCSIDriver := testlib.GetClusterCSIDriver(false)
 			testlib.AddClusterCSIDriverClient(commonApiClient, clusterCSIDriver)
 
@@ -400,88 +673,91 @@ vsphere_csi_driver_error{condition="upgrade_blocked",failure_reason="existing_dr
 			scController := ctrl.storageClassController.(*dummyStorageClassController)
 
 			var cleanUpFunc func()
-			var conn *vclib.VSphereConnection
+			var connections []*vclib.VSphereConnection
 			var connError error
-			conn, cleanUpFunc, connError = testlib.SetupSimulator(testlib.DefaultModel)
-			if test.vcenterVersion != "" {
-				testlib.CustomizeVCenterVersion(test.vcenterVersion, test.vcenterVersion, conn)
-			}
-			ctrl.vsphereConnectionFunc = makeVsphereConnectionFunc(conn, test.failVCenterConnection, connError)
-			defer func() {
-				if cleanUpFunc != nil {
-					cleanUpFunc()
+			connections, cleanUpFunc, connError = testlib.SetupSimulator(testlib.DefaultModel, test.infra)
+
+			for _, conn := range connections {
+				if test.vcenterVersion != "" {
+					testlib.CustomizeVCenterVersion(test.vcenterVersion, test.vcenterVersion, conn)
 				}
-			}()
-			err := setHardwareVersionsFunc(nodes, conn, test.startingNodeHardwareVersions)()
-			if err != nil {
-				t.Fatalf("error setting hardware version for node %s", nodes[0].Name)
-			}
-
-			hostVersion := test.hostVersion
-			if hostVersion == "" {
-				hostVersion = "7.0.2"
-			}
-			err = testlib.CustomizeHostVersion(testlib.DefaultHostId, hostVersion)
-			if err != nil {
-				t.Fatalf("Failed to customize host: %s", err)
-			}
-
-			if test.skipCheck {
-				ctrl.vSphereChecker = newSkippingChecker()
-			}
-
-			err = ctrl.sync(context.TODO(), factory.NewSyncContext("vsphere-controller", ctrl.eventRecorder))
-			if test.expectError == nil && err != nil {
-				t.Fatalf("Unexpected error that could degrade cluster: %+v", err)
-			}
-
-			// check storageclass results
-			if test.storageClassCreated && scController.syncCalled == 0 {
-				t.Fatalf("expected storageclass to be created")
-			}
-
-			if !test.storageClassCreated && scController.syncCalled > 0 {
-				t.Fatalf("unexpected storageclass created")
-			}
-
-			if test.expectError != nil && err == nil {
-				t.Fatalf("expected cluster to be degraded with: %v, got none", test.expectError)
-			}
-			// if hardware version changes between the syncs lets rerun sync again
-			if len(test.finalNodeHardwareVersions) > 0 {
-				err = adjustConditionsAndResync(setHardwareVersionsFunc(nodes, conn, test.finalNodeHardwareVersions), ctrl)
-			}
-
-			_, status, _, err := ctrl.operatorClient.GetOperatorState()
-			if err != nil {
-				t.Errorf("failed to get operator state: %+v", err)
-			}
-			extraConditions := sets.New[string]()
-			for i := range status.Conditions {
-				extraConditions.Insert(status.Conditions[i].Type)
-			}
-			for i := range test.expectedConditions {
-				expectedCondition := test.expectedConditions[i]
-				matchingCondition := testlib.GetMatchingCondition(status.Conditions, expectedCondition.Type)
-				if matchingCondition == nil {
-					t.Fatalf("found no matching condition for: %s", expectedCondition.Type)
+				ctrl.vsphereConnectionFunc = makeVsphereConnectionFunc(conn, test.failVCenterConnection, connError)
+				defer func() {
+					if cleanUpFunc != nil {
+						cleanUpFunc()
+					}
+				}()
+				err := setHardwareVersionsFunc(nodes, conn, test.startingNodeHardwareVersions)()
+				if err != nil {
+					t.Fatalf("error setting hardware version for node %s", nodes[0].Name)
 				}
-				if matchingCondition.Status != expectedCondition.Status {
-					t.Fatalf("for condition %s: expected status: %v, got: %v", expectedCondition.Type, expectedCondition.Status, matchingCondition.Status)
+
+				hostVersion := test.hostVersion
+				if hostVersion == "" {
+					hostVersion = "7.0.2"
 				}
-				extraConditions.Delete(expectedCondition.Type)
-			}
-			if len(extraConditions) > 0 {
-				t.Fatalf("found unexpected conditions: %+v", extraConditions.UnsortedList())
-			}
+				err = testlib.CustomizeHostVersion(testlib.DefaultHostId, hostVersion)
+				if err != nil {
+					t.Fatalf("Failed to customize host: %s", err)
+				}
 
-			if test.operandStarted != ctrl.operandControllerStarted {
-				t.Fatalf("expected operandStarted to be %v, got %v", test.operandStarted, ctrl.operandControllerStarted)
-			}
+				if test.skipCheck {
+					ctrl.vSphereChecker = newSkippingChecker()
+				}
 
-			if test.expectedMetrics != "" {
-				if err := testutil.CollectAndCompare(utils.InstallErrorMetric, strings.NewReader(metricsHeader+test.expectedMetrics+"\n"), utils.InstallErrorMetric.Name); err != nil {
-					t.Errorf("wrong metrics: %s", err)
+				err = ctrl.sync(context.TODO(), factory.NewSyncContext("vsphere-controller", ctrl.eventRecorder))
+				if test.expectError == nil && err != nil {
+					t.Fatalf("Unexpected error that could degrade cluster: %+v", err)
+				}
+
+				// check storageclass results
+				if test.storageClassCreated && scController.syncCalled == 0 {
+					t.Fatalf("expected storageclass to be created")
+				}
+
+				if !test.storageClassCreated && scController.syncCalled > 0 {
+					t.Fatalf("unexpected storageclass created")
+				}
+
+				if test.expectError != nil && err == nil {
+					t.Fatalf("expected cluster to be degraded with: %v, got none", test.expectError)
+				}
+				// if hardware version changes between the syncs lets rerun sync again
+				if len(test.finalNodeHardwareVersions) > 0 {
+					err = adjustConditionsAndResync(setHardwareVersionsFunc(nodes, conn, test.finalNodeHardwareVersions), ctrl)
+				}
+
+				_, status, _, err := ctrl.operatorClient.GetOperatorState()
+				if err != nil {
+					t.Errorf("failed to get operator state: %+v", err)
+				}
+				extraConditions := sets.New[string]()
+				for i := range status.Conditions {
+					extraConditions.Insert(status.Conditions[i].Type)
+				}
+				for i := range test.expectedConditions {
+					expectedCondition := test.expectedConditions[i]
+					matchingCondition := testlib.GetMatchingCondition(status.Conditions, expectedCondition.Type)
+					if matchingCondition == nil {
+						t.Fatalf("found no matching condition for: %s", expectedCondition.Type)
+					}
+					if matchingCondition.Status != expectedCondition.Status {
+						t.Fatalf("for condition %s: expected status: %v, got: %v", expectedCondition.Type, expectedCondition.Status, matchingCondition.Status)
+					}
+					extraConditions.Delete(expectedCondition.Type)
+				}
+				if len(extraConditions) > 0 {
+					t.Fatalf("found unexpected conditions: %+v", extraConditions.UnsortedList())
+				}
+
+				if test.operandStarted != ctrl.operandControllerStarted {
+					t.Fatalf("expected operandStarted to be %v, got %v", test.operandStarted, ctrl.operandControllerStarted)
+				}
+
+				if test.expectedMetrics != "" {
+					if err := testutil.CollectAndCompare(utils.InstallErrorMetric, strings.NewReader(metricsHeader+test.expectedMetrics+"\n"), utils.InstallErrorMetric.Name); err != nil {
+						t.Errorf("wrong metrics: %s", err)
+					}
 				}
 			}
 		})
@@ -489,43 +765,89 @@ vsphere_csi_driver_error{condition="upgrade_blocked",failure_reason="existing_dr
 }
 
 func TestApplyClusterCSIDriver(t *testing.T) {
+	multiVCenterGateDisabled := featuregates.NewFeatureGate([]configv1.FeatureGateName{"SomeEnabledFeatureGate"}, []configv1.FeatureGateName{"SomeDisabledFeatureGate", features.FeatureGateVSphereMultiVCenters})
+
 	tests := []struct {
-		name               string
-		clusterCSIDriver   *opv1.ClusterCSIDriver
-		operatorObj        *testlib.FakeDriverInstance
-		expectedTopology   string
-		configFileName     string
-		expectedDatacenter string
-		expectError        bool
+		name                  string
+		clusterCSIDriver      *opv1.ClusterCSIDriver
+		operatorObj           *testlib.FakeDriverInstance
+		expectedTopology      string
+		configFileName        string
+		secretData            runtime.Object
+		featureGates          featuregates.FeatureGate
+		expectedDatacenterMap map[string]string
+		expectError           bool
 	}{
 		{
-			name:               "when driver does not have topology enabled",
-			clusterCSIDriver:   testlib.GetClusterCSIDriver(false),
-			operatorObj:        testlib.MakeFakeDriverInstance(),
-			expectedDatacenter: "Datacenter",
-			expectedTopology:   "",
+			name:             "when driver does not have topology enabled",
+			clusterCSIDriver: testlib.GetClusterCSIDriver(false),
+			operatorObj:      testlib.MakeFakeDriverInstance(),
+			secretData:       testlib.GetDCSecret(),
+			expectedDatacenterMap: map[string]string{
+				"foobar.lan": "Datacenter",
+			},
+			expectedTopology: "",
 		},
 		{
-			name:               "when driver does have topology enabled",
-			clusterCSIDriver:   testlib.GetClusterCSIDriver(true),
-			operatorObj:        testlib.MakeFakeDriverInstance(),
-			expectedDatacenter: "Datacenter",
-			expectedTopology:   "k8s-zone,k8s-region",
+			name:             "when driver does have topology enabled",
+			clusterCSIDriver: testlib.GetClusterCSIDriver(true),
+			operatorObj:      testlib.MakeFakeDriverInstance(),
+			secretData:       testlib.GetDCSecret(),
+			expectedDatacenterMap: map[string]string{
+				"foobar.lan": "Datacenter",
+			},
+			expectedTopology: "k8s-zone,k8s-region",
 		},
 		{
 			name:             "when configuration has more than one vcenter",
 			clusterCSIDriver: testlib.GetClusterCSIDriver(true),
 			operatorObj:      testlib.MakeFakeDriverInstance(),
 			configFileName:   "multiple_vc.ini",
+			secretData:       testlib.GetDCSecret(),
 			expectError:      true,
 		},
 		{
-			name:               "when configuration has more than one datacenter",
-			clusterCSIDriver:   testlib.GetClusterCSIDriver(true),
-			operatorObj:        testlib.MakeFakeDriverInstance(),
-			configFileName:     "multiple_dc.ini",
-			expectedDatacenter: "Datacentera, DatacenterB",
-			expectedTopology:   "k8s-zone,k8s-region",
+			name:             "when configuration has more than one vcenter yaml",
+			clusterCSIDriver: testlib.GetClusterCSIDriver(true),
+			operatorObj:      testlib.MakeFakeDriverInstance(),
+			configFileName:   "multiple_vc.yaml",
+			secretData:       testlib.GetMultiVCSecret(),
+			expectError:      true,
+		},
+		{
+			name:             "when configuration has more than one vcenter yaml gate enabled",
+			clusterCSIDriver: testlib.GetClusterCSIDriver(true),
+			operatorObj:      testlib.MakeFakeDriverInstance(),
+			configFileName:   "multiple_vc.yaml",
+			secretData:       testlib.GetMultiVCSecret(),
+			featureGates:     featuregates.NewFeatureGate([]configv1.FeatureGateName{"SomeEnabledFeatureGate", features.FeatureGateVSphereMultiVCenters}, []configv1.FeatureGateName{"SomeDisabledFeatureGate"}),
+			expectedDatacenterMap: map[string]string{
+				"foobar.lan": "Datacenter",
+				"foobaz.lan": "Datacenterb",
+			},
+			expectedTopology: "k8s-zone,k8s-region",
+		},
+		{
+			name:             "when configuration has more than one datacenter",
+			clusterCSIDriver: testlib.GetClusterCSIDriver(true),
+			operatorObj:      testlib.MakeFakeDriverInstance(),
+			configFileName:   "multiple_dc.ini",
+			secretData:       testlib.GetDCSecret(),
+			expectedDatacenterMap: map[string]string{
+				"foobar.lan": "Datacentera, DatacenterB", // INI has a space, YAML does not
+			},
+			expectedTopology: "k8s-zone,k8s-region",
+		},
+		{
+			name:             "when configuration has more than one datacenter yaml",
+			clusterCSIDriver: testlib.GetClusterCSIDriver(true),
+			operatorObj:      testlib.MakeFakeDriverInstance(),
+			configFileName:   "multiple_dc.yaml",
+			secretData:       testlib.GetDCSecret(),
+			expectedDatacenterMap: map[string]string{
+				"foobar.lan": "Datacentera,DatacenterB", // INI has a space, YAML does not
+			},
+			expectedTopology: "k8s-zone,k8s-region",
 		},
 	}
 
@@ -533,26 +855,31 @@ func TestApplyClusterCSIDriver(t *testing.T) {
 		tc := tests[i]
 		t.Run(tc.name, func(t *testing.T) {
 			infra := testlib.GetInfraObject()
-			initialObjects := []runtime.Object{testlib.GetConfigMap(), testlib.GetSecret()}
+			initialObjects := []runtime.Object{tc.secretData}
 			commonApiClient := testlib.NewFakeClients(initialObjects, tc.operatorObj, infra)
 			testlib.AddClusterCSIDriverClient(commonApiClient, tc.clusterCSIDriver)
 			stopCh := make(chan struct{})
 			defer close(stopCh)
 
 			go testlib.StartFakeInformer(commonApiClient, stopCh)
-			if err := testlib.AddInitialObjects(initialObjects, commonApiClient); err != nil {
+			if err := testlib.AddInitialObjects(append(initialObjects, tc.clusterCSIDriver), commonApiClient); err != nil {
 				t.Fatalf("error adding initial objects: %v", err)
 			}
 
-			testlib.WaitForSync(commonApiClient, stopCh)
-			ctrl := newVsphereController(commonApiClient)
+			gates := tc.featureGates
+			if gates == nil {
+				gates = multiVCenterGateDisabled
+			}
 
-			legacyVsphereConfig, err := testlib.GetLegacyVSphereConfig(tc.configFileName)
+			testlib.WaitForSync(commonApiClient, stopCh)
+			ctrl := newVsphereControllerWithGates(commonApiClient, gates)
+
+			vsphereConfig, err := testlib.GetVSphereConfig(tc.configFileName)
 			if err != nil {
 				t.Fatalf("error loading legacy vsphere config: %v", err)
 			}
 
-			configMap, err := ctrl.applyClusterCSIDriverChange(infra, legacyVsphereConfig, tc.clusterCSIDriver, "foobar")
+			configMap, err := ctrl.applyClusterCSIDriverChange(infra, vsphereConfig, tc.clusterCSIDriver, "foobar")
 
 			// if we expected error and we got some, we should stop running this test
 			if tc.expectError && err != nil {
@@ -581,12 +908,20 @@ func TestApplyClusterCSIDriver(t *testing.T) {
 					t.Fatalf("expected topology %v, unexpected topology found %v", tc.expectedTopology, labelSection)
 				}
 			}
-			datacenters, err := csiConfig.Section("VirtualCenter \"foobar.lan\"").GetKey("datacenters")
-			if err != nil {
-				t.Fatalf("error getting datacenters: %v", err)
-			}
-			if datacenters.String() != tc.expectedDatacenter {
-				t.Fatalf("expected datacenter to be %s, got %s", tc.expectedDatacenter, datacenters.String())
+
+			// We need to iterate through each vcenter and verify.
+			if tc.expectedDatacenterMap != nil {
+				for key := range tc.expectedDatacenterMap {
+					fmt.Printf("VirtualCenter \"%v\"\n", key)
+					fmt.Printf("Section %v\n", csiConfig.Section(fmt.Sprintf("VirtualCenter \"%v\"", key)))
+					datacenters, err := csiConfig.Section(fmt.Sprintf("VirtualCenter \"%v\"", key)).GetKey("datacenters")
+					if err != nil {
+						t.Fatalf("error getting datacenters: %v", err)
+					}
+					if datacenters.String() != tc.expectedDatacenterMap[key] {
+						t.Fatalf("expected datacenter for vcenter %v to be %s, got %s", key, tc.expectedDatacenterMap[key], datacenters.String())
+					}
+				}
 			}
 
 			datastoreURL, err := csiConfig.Section("VirtualCenter \"foobar.lan\"").GetKey("migration-datastore-url")
@@ -683,8 +1018,8 @@ func adjustConditionsAndResync(modifierFunc func() error, ctrl *VSphereControlle
 	return ctrl.sync(context.TODO(), factory.NewSyncContext("vsphere-controller", ctrl.eventRecorder))
 }
 
-func makeVsphereConnectionFunc(conn *vclib.VSphereConnection, failConnection bool, connError error) func() (*vclib.VSphereConnection, checks.ClusterCheckResult, bool) {
-	return func() (*vclib.VSphereConnection, checks.ClusterCheckResult, bool) {
+func makeVsphereConnectionFunc(conn *vclib.VSphereConnection, failConnection bool, connError error) func() ([]*vclib.VSphereConnection, checks.ClusterCheckResult, bool) {
+	return func() ([]*vclib.VSphereConnection, checks.ClusterCheckResult, bool) {
 		if failConnection {
 			err := fmt.Errorf("connection to vcenter failed")
 			result := checks.ClusterCheckResult{
@@ -698,7 +1033,7 @@ func makeVsphereConnectionFunc(conn *vclib.VSphereConnection, failConnection boo
 			if connError != nil {
 				return nil, checks.MakeGenericVCenterAPIError(connError), false
 			}
-			return conn, checks.MakeClusterCheckResultPass(), false
+			return []*vclib.VSphereConnection{conn}, checks.MakeClusterCheckResultPass(), false
 		}
 	}
 }

--- a/third_party/cloud-provider-vsphere/pkg/common/config/config.go
+++ b/third_party/cloud-provider-vsphere/pkg/common/config/config.go
@@ -1,0 +1,285 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	klog "k8s.io/klog/v2"
+)
+
+/*
+	TODO:
+	When the INI based cloud-config is deprecated, this functions below should be preserved
+*/
+
+func getEnvKeyValue(match string, partial bool) (string, string, error) {
+	for _, e := range os.Environ() {
+		pair := strings.Split(e, "=")
+		if len(pair) != 2 {
+			continue
+		}
+
+		key := pair[0]
+		value := pair[1]
+
+		if partial && strings.Contains(key, match) {
+			return key, value, nil
+		}
+
+		if strings.Compare(key, match) == 0 {
+			return key, value, nil
+		}
+	}
+
+	matchType := "match"
+	if partial {
+		matchType = "partial match"
+	}
+
+	return "", "", fmt.Errorf("Failed to find %s with %s", matchType, match)
+}
+
+// FromEnv initializes the provided configuratoin object with values
+// obtained from environment variables. If an environment variable is set
+// for a property that's already initialized, the environment variable's value
+// takes precedence.
+func (cfg *Config) FromEnv() error {
+
+	//Init
+	if cfg.VirtualCenter == nil {
+		cfg.VirtualCenter = make(map[string]*VirtualCenterConfig)
+	}
+
+	//Globals
+	if v := os.Getenv("VSPHERE_VCENTER"); v != "" {
+		cfg.Global.VCenterIP = v
+	}
+	if v := os.Getenv("VSPHERE_VCENTER_PORT"); v != "" {
+		cfg.Global.VCenterPort = v
+	}
+	if v := os.Getenv("VSPHERE_USER"); v != "" {
+		cfg.Global.User = v
+	}
+	if v := os.Getenv("VSPHERE_PASSWORD"); v != "" {
+		cfg.Global.Password = v
+	}
+	if v := os.Getenv("VSPHERE_DATACENTER"); v != "" {
+		cfg.Global.Datacenters = v
+	}
+	if v := os.Getenv("VSPHERE_SECRET_NAME"); v != "" {
+		cfg.Global.SecretName = v
+	}
+	if v := os.Getenv("VSPHERE_SECRET_NAMESPACE"); v != "" {
+		cfg.Global.SecretNamespace = v
+	}
+
+	if v := os.Getenv("VSPHERE_ROUNDTRIP_COUNT"); v != "" {
+		tmp, err := strconv.ParseUint(v, 10, 32)
+		if err != nil {
+			klog.Errorf("Failed to parse VSPHERE_ROUNDTRIP_COUNT: %s", err)
+		} else {
+			cfg.Global.RoundTripperCount = uint(tmp)
+		}
+	}
+
+	if v := os.Getenv("VSPHERE_INSECURE"); v != "" {
+		InsecureFlag, err := strconv.ParseBool(v)
+		if err != nil {
+			klog.Errorf("Failed to parse VSPHERE_INSECURE: %s", err)
+		} else {
+			cfg.Global.InsecureFlag = InsecureFlag
+		}
+	}
+
+	if v := os.Getenv("VSPHERE_SECRETS_DIRECTORY"); v != "" {
+		cfg.Global.SecretsDirectory = v
+	}
+	if cfg.Global.SecretsDirectory == "" {
+		cfg.Global.SecretsDirectory = DefaultSecretDirectory
+	}
+	if _, err := os.Stat(cfg.Global.SecretsDirectory); os.IsNotExist(err) {
+		cfg.Global.SecretsDirectory = "" //Dir does not exist, set to empty string
+	}
+
+	if v := os.Getenv("VSPHERE_CAFILE"); v != "" {
+		cfg.Global.CAFile = v
+	}
+	if v := os.Getenv("VSPHERE_THUMBPRINT"); v != "" {
+		cfg.Global.Thumbprint = v
+	}
+	if v := os.Getenv("VSPHERE_LABEL_REGION"); v != "" {
+		cfg.Labels.Region = v
+	}
+	if v := os.Getenv("VSPHERE_LABEL_ZONE"); v != "" {
+		cfg.Labels.Zone = v
+	}
+
+	//Build VirtualCenter from ENVs
+	for _, e := range os.Environ() {
+		pair := strings.Split(e, "=")
+
+		if len(pair) != 2 {
+			continue
+		}
+
+		key := pair[0]
+		value := pair[1]
+
+		if strings.HasPrefix(key, "VSPHERE_VCENTER_") && len(value) > 0 {
+			id := strings.TrimPrefix(key, "VSPHERE_VCENTER_")
+			vcenter := value
+
+			_, username, errUsername := getEnvKeyValue("VCENTER_"+id+"_USERNAME", false)
+			if errUsername != nil {
+				username = cfg.Global.User
+			}
+			_, password, errPassword := getEnvKeyValue("VCENTER_"+id+"_PASSWORD", false)
+			if errPassword != nil {
+				password = cfg.Global.Password
+			}
+			_, server, errServer := getEnvKeyValue("VCENTER_"+id+"_SERVER", false)
+			if errServer != nil {
+				server = ""
+			}
+			_, port, errPort := getEnvKeyValue("VCENTER_"+id+"_PORT", false)
+			if errPort != nil {
+				port = cfg.Global.VCenterPort
+			}
+			insecureFlag := false
+			_, insecureTmp, errInsecure := getEnvKeyValue("VCENTER_"+id+"_INSECURE", false)
+			if errInsecure != nil {
+				insecureFlagTmp, errTmp := strconv.ParseBool(insecureTmp)
+				if errTmp == nil {
+					insecureFlag = insecureFlagTmp
+				}
+			}
+			_, datacenters, errDatacenters := getEnvKeyValue("VCENTER_"+id+"_DATACENTERS", false)
+			if errDatacenters != nil {
+				datacenters = cfg.Global.Datacenters
+			}
+			roundtrip := DefaultRoundTripperCount
+			_, roundtripTmp, errRoundtrip := getEnvKeyValue("VCENTER_"+id+"_ROUNDTRIP", false)
+			if errRoundtrip != nil {
+				roundtripFlagTmp, errTmp := strconv.ParseUint(roundtripTmp, 10, 32)
+				if errTmp == nil {
+					roundtrip = uint(roundtripFlagTmp)
+				}
+			}
+			_, caFile, errCaFile := getEnvKeyValue("VCENTER_"+id+"_CAFILE", false)
+			if errCaFile != nil {
+				caFile = cfg.Global.CAFile
+			}
+			_, thumbprint, errThumbprint := getEnvKeyValue("VCENTER_"+id+"_THUMBPRINT", false)
+			if errThumbprint != nil {
+				thumbprint = cfg.Global.Thumbprint
+			}
+
+			_, secretName, secretNameErr := getEnvKeyValue("VCENTER_"+id+"_SECRET_NAME", false)
+			_, secretNamespace, secretNamespaceErr := getEnvKeyValue("VCENTER_"+id+"_SECRET_NAMESPACE", false)
+
+			if secretNameErr != nil || secretNamespaceErr != nil {
+				secretName = ""
+				secretNamespace = ""
+			}
+			secretRef := DefaultCredentialManager
+			if secretName != "" && secretNamespace != "" {
+				secretRef = vcenter
+			}
+
+			iPFamilyPriority := []string{DefaultIPFamily}
+			_, ipFamily, errIPFamily := getEnvKeyValue("VCENTER_"+id+"_IP_FAMILY", false)
+			if errIPFamily != nil {
+				iPFamilyPriority = []string{ipFamily}
+			}
+
+			// If server is explicitly set, that means the vcenter value above is the TenantRef
+			vcenterIP := vcenter
+			tenantRef := vcenter
+			if server != "" {
+				vcenterIP = server
+				tenantRef = vcenter
+			}
+
+			var vcc *VirtualCenterConfig
+			if cfg.VirtualCenter[tenantRef] != nil {
+				vcc = cfg.VirtualCenter[tenantRef]
+			} else {
+				vcc = &VirtualCenterConfig{}
+				cfg.VirtualCenter[tenantRef] = vcc
+			}
+
+			vcc.User = username
+			vcc.Password = password
+			vcc.TenantRef = tenantRef
+			vcc.VCenterIP = vcenterIP
+			vcc.VCenterPort = port
+			vcc.InsecureFlag = insecureFlag
+			vcc.Datacenters = datacenters
+			vcc.RoundTripperCount = roundtrip
+			vcc.CAFile = caFile
+			vcc.Thumbprint = thumbprint
+			vcc.SecretRef = secretRef
+			vcc.SecretName = secretName
+			vcc.SecretNamespace = secretNamespace
+			vcc.IPFamilyPriority = iPFamilyPriority
+		}
+	}
+
+	return nil
+}
+
+/*
+	TODO:
+	When the INI based cloud-config is deprecated, the references to the
+	INI based code (ie the call to ReadConfigINI) below should be deleted.
+*/
+
+// ReadConfig parses vSphere cloud config file and stores it into VSphereConfig.
+// Environment variables are also checked
+func ReadConfig(byConfig []byte) (*Config, error) {
+	if len(byConfig) == 0 {
+		return nil, fmt.Errorf("Invalid YAML/INI file")
+	}
+
+	cfg, err := ReadConfigYAML(byConfig)
+	if err != nil {
+		klog.V(4).Infof("ReadConfigYAML failed: %s", err)
+
+		cfg, err = ReadConfigINI(byConfig)
+		if err != nil {
+			klog.Errorf("ReadConfigINI failed: %s", err)
+			return nil, err
+		}
+
+		klog.Info("ReadConfig INI succeeded. INI-based cloud-config is deprecated and will be removed in 2.0. Please use YAML based cloud-config.")
+	} else {
+		klog.Info("ReadConfig YAML succeeded")
+	}
+
+	// Env Vars should override config file entries if present
+	if err := cfg.FromEnv(); err != nil {
+		klog.Errorf("FromEnv failed: %s", err)
+		return nil, err
+	}
+
+	klog.Info("Config initialized")
+	return cfg, nil
+}

--- a/third_party/cloud-provider-vsphere/pkg/common/config/config_ini_legacy.go
+++ b/third_party/cloud-provider-vsphere/pkg/common/config/config_ini_legacy.go
@@ -1,0 +1,265 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	ini "gopkg.in/gcfg.v1"
+	klog "k8s.io/klog/v2"
+)
+
+/*
+	TODO:
+	When the INI based cloud-config is deprecated. This file should be deleted.
+*/
+
+// CreateConfig generates a common Config object based on what other structs and funcs
+// are already dependent upon in other packages.
+func (cci *CommonConfigINI) CreateConfig() *Config {
+	cfg := &Config{
+		VirtualCenter: make(map[string]*VirtualCenterConfig),
+	}
+
+	cfg.Global.User = cci.Global.User
+	cfg.Global.Password = cci.Global.Password
+	cfg.Global.VCenterIP = cci.Global.VCenterIP
+	cfg.Global.VCenterPort = cci.Global.VCenterPort
+	cfg.Global.InsecureFlag = cci.Global.InsecureFlag
+	cfg.Global.Datacenters = cci.Global.Datacenters
+	cfg.Global.RoundTripperCount = cci.Global.RoundTripperCount
+	cfg.Global.CAFile = cci.Global.CAFile
+	cfg.Global.Thumbprint = cci.Global.Thumbprint
+	cfg.Global.SecretName = cci.Global.SecretName
+	cfg.Global.SecretNamespace = cci.Global.SecretNamespace
+	cfg.Global.SecretsDirectory = cci.Global.SecretsDirectory
+
+	for keyVcConfig, valVcConfig := range cci.VirtualCenter {
+		cfg.VirtualCenter[keyVcConfig] = &VirtualCenterConfig{
+			User:              valVcConfig.User,
+			Password:          valVcConfig.Password,
+			TenantRef:         valVcConfig.TenantRef,
+			VCenterIP:         valVcConfig.VCenterIP,
+			VCenterPort:       valVcConfig.VCenterPort,
+			InsecureFlag:      valVcConfig.InsecureFlag,
+			Datacenters:       valVcConfig.Datacenters,
+			RoundTripperCount: valVcConfig.RoundTripperCount,
+			CAFile:            valVcConfig.CAFile,
+			Thumbprint:        valVcConfig.Thumbprint,
+			SecretRef:         valVcConfig.SecretRef,
+			SecretName:        valVcConfig.SecretName,
+			SecretNamespace:   valVcConfig.SecretNamespace,
+			IPFamilyPriority:  valVcConfig.IPFamilyPriority,
+		}
+	}
+
+	cfg.Labels.Region = cci.Labels.Region
+	cfg.Labels.Zone = cci.Labels.Zone
+
+	return cfg
+}
+
+// validateIPFamily takes the possible values of IPFamily and initializes the
+// slice as determined bby priority
+func (vcci *VirtualCenterConfigINI) validateIPFamily() error {
+	if len(vcci.IPFamily) == 0 {
+		vcci.IPFamily = DefaultIPFamily
+	}
+
+	ipFamilies := strings.Split(vcci.IPFamily, ",")
+	for i, ipFamily := range ipFamilies {
+		ipFamily = strings.TrimSpace(ipFamily)
+		if len(ipFamily) == 0 {
+			copy(ipFamilies[i:], ipFamilies[i+1:])      // Shift a[i+1:] left one index.
+			ipFamilies[len(ipFamilies)-1] = ""          // Erase last element (write zero value).
+			ipFamilies = ipFamilies[:len(ipFamilies)-1] // Truncate slice.
+			continue
+		}
+		if !strings.EqualFold(ipFamily, IPv4Family) && !strings.EqualFold(ipFamily, IPv6Family) {
+			return ErrInvalidIPFamilyType
+		}
+	}
+
+	vcci.IPFamilyPriority = ipFamilies
+	return nil
+}
+
+// isSecretInfoProvided returns true if k8s secret is set or using generic CO secret method.
+// If both k8s secret and generic CO both are true, we don't know which to use, so return false.
+func (cci *CommonConfigINI) isSecretInfoProvided() bool {
+	return (cci.Global.SecretName != "" && cci.Global.SecretNamespace != "" && cci.Global.SecretsDirectory == "") ||
+		(cci.Global.SecretName == "" && cci.Global.SecretNamespace == "" && cci.Global.SecretsDirectory != "")
+}
+
+// isSecretInfoProvided returns true if the secret per VC has been configured
+func (vcci *VirtualCenterConfigINI) isSecretInfoProvided() bool {
+	return vcci.SecretName != "" && vcci.SecretNamespace != ""
+}
+
+func (cci *CommonConfigINI) validateConfig() error {
+	//Fix default global values
+	if cci.Global.RoundTripperCount == 0 {
+		cci.Global.RoundTripperCount = DefaultRoundTripperCount
+	}
+	if cci.Global.VCenterPort == "" {
+		cci.Global.VCenterPort = DefaultVCenterPortStr
+	}
+	if cci.Global.APIBinding == "" {
+		cci.Global.APIBinding = DefaultAPIBinding
+	}
+	if cci.Global.IPFamily == "" {
+		cci.Global.IPFamily = DefaultIPFamily
+	}
+
+	// Create a single instance of VSphereInstance for the Global VCenterIP if the
+	// VirtualCenter does not already exist in the map
+	if cci.Global.VCenterIP != "" && cci.VirtualCenter[cci.Global.VCenterIP] == nil {
+		cci.VirtualCenter[cci.Global.VCenterIP] = &VirtualCenterConfigINI{
+			User:              cci.Global.User,
+			Password:          cci.Global.Password,
+			TenantRef:         cci.Global.VCenterIP,
+			VCenterIP:         cci.Global.VCenterIP,
+			VCenterPort:       cci.Global.VCenterPort,
+			InsecureFlag:      cci.Global.InsecureFlag,
+			Datacenters:       cci.Global.Datacenters,
+			RoundTripperCount: cci.Global.RoundTripperCount,
+			CAFile:            cci.Global.CAFile,
+			Thumbprint:        cci.Global.Thumbprint,
+			SecretRef:         DefaultCredentialManager,
+			SecretName:        cci.Global.SecretName,
+			SecretNamespace:   cci.Global.SecretNamespace,
+			IPFamily:          cci.Global.IPFamily,
+		}
+	}
+
+	// Must have at least one vCenter defined
+	if len(cci.VirtualCenter) == 0 {
+		klog.Error(ErrMissingVCenter)
+		return ErrMissingVCenter
+	}
+
+	// vsphere.conf is no longer supported in the old format.
+	for vcServer, vcConfig := range cci.VirtualCenter {
+		klog.V(4).Infof("Initializing vc server %s", vcServer)
+		if vcServer == "" {
+			klog.Error(ErrInvalidVCenterIP)
+			return ErrInvalidVCenterIP
+		}
+
+		// If vcConfig.VCenterIP is explicitly set, that means the vcServer
+		// above is the TenantRef
+		if vcConfig.VCenterIP != "" {
+			//vcConfig.VCenterIP is already set
+			vcConfig.TenantRef = vcServer
+		} else {
+			vcConfig.VCenterIP = vcServer
+			vcConfig.TenantRef = vcServer
+		}
+
+		if !cci.isSecretInfoProvided() && !vcConfig.isSecretInfoProvided() {
+			if vcConfig.User == "" {
+				vcConfig.User = cci.Global.User
+				if vcConfig.User == "" {
+					klog.Errorf("vcConfig.User is empty for vc %s!", vcServer)
+					return ErrUsernameMissing
+				}
+			}
+			if vcConfig.Password == "" {
+				vcConfig.Password = cci.Global.Password
+				if vcConfig.Password == "" {
+					klog.Errorf("vcConfig.Password is empty for vc %s!", vcServer)
+					return ErrPasswordMissing
+				}
+			}
+		} else if cci.isSecretInfoProvided() && !vcConfig.isSecretInfoProvided() {
+			vcConfig.SecretRef = DefaultCredentialManager
+		} else if vcConfig.isSecretInfoProvided() {
+			vcConfig.SecretRef = vcConfig.SecretNamespace + "/" + vcConfig.SecretName
+		}
+
+		if vcConfig.VCenterPort == "" {
+			vcConfig.VCenterPort = cci.Global.VCenterPort
+		}
+
+		if vcConfig.Datacenters == "" {
+			if cci.Global.Datacenters != "" {
+				vcConfig.Datacenters = cci.Global.Datacenters
+			}
+		}
+		if vcConfig.RoundTripperCount == 0 {
+			vcConfig.RoundTripperCount = cci.Global.RoundTripperCount
+		}
+		if vcConfig.CAFile == "" {
+			vcConfig.CAFile = cci.Global.CAFile
+		}
+		if vcConfig.Thumbprint == "" {
+			vcConfig.Thumbprint = cci.Global.Thumbprint
+		}
+
+		if vcConfig.IPFamily == "" {
+			vcConfig.IPFamily = cci.Global.IPFamily
+		}
+
+		err := vcConfig.validateIPFamily()
+		if err != nil {
+			klog.Errorf("Invalid vcConfig IPFamily: %s, err=%s", vcConfig.IPFamily, err)
+			return err
+		}
+
+		insecure := vcConfig.InsecureFlag
+		if !insecure {
+			vcConfig.InsecureFlag = cci.Global.InsecureFlag
+		}
+	}
+
+	return nil
+}
+
+// ReadRawConfigINI parses vSphere cloud config file and stores it into ConfigINI
+func ReadRawConfigINI(byConfig []byte) (*CommonConfigINI, error) {
+	if len(byConfig) == 0 {
+		return nil, fmt.Errorf("Invalid INI file")
+	}
+
+	strConfig := string(byConfig[:])
+
+	cfg := &CommonConfigINI{
+		VirtualCenter: make(map[string]*VirtualCenterConfigINI),
+	}
+
+	if err := ini.FatalOnly(ini.ReadStringInto(cfg, strConfig)); err != nil {
+		return nil, err
+	}
+
+	err := cfg.validateConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+// ReadConfigINI parses vSphere cloud config file and stores it into Config
+func ReadConfigINI(byConfig []byte) (*Config, error) {
+	cfg, err := ReadRawConfigINI(byConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg.CreateConfig(), nil
+}

--- a/third_party/cloud-provider-vsphere/pkg/common/config/config_yaml.go
+++ b/third_party/cloud-provider-vsphere/pkg/common/config/config_yaml.go
@@ -1,0 +1,229 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	yaml "gopkg.in/yaml.v2"
+	klog "k8s.io/klog/v2"
+)
+
+/*
+	TODO:
+	When the INI based cloud-config is deprecated, this file should be merged into config.go
+	and this file should be deleted.
+*/
+
+// CreateConfig generates a common Config object based on what other structs and funcs
+// are already dependent upon in other packages.
+func (ccy *CommonConfigYAML) CreateConfig() *Config {
+	cfg := &Config{
+		VirtualCenter: make(map[string]*VirtualCenterConfig),
+	}
+
+	cfg.Global.User = ccy.Global.User
+	cfg.Global.Password = ccy.Global.Password
+	cfg.Global.VCenterIP = ccy.Global.VCenterIP
+	cfg.Global.VCenterPort = fmt.Sprint(ccy.Global.VCenterPort)
+	cfg.Global.InsecureFlag = ccy.Global.InsecureFlag
+	cfg.Global.Datacenters = strings.Join(ccy.Global.Datacenters, ",")
+	cfg.Global.RoundTripperCount = ccy.Global.RoundTripperCount
+	cfg.Global.CAFile = ccy.Global.CAFile
+	cfg.Global.Thumbprint = ccy.Global.Thumbprint
+	cfg.Global.SecretName = ccy.Global.SecretName
+	cfg.Global.SecretNamespace = ccy.Global.SecretNamespace
+	cfg.Global.SecretsDirectory = ccy.Global.SecretsDirectory
+
+	for keyVcConfig, valVcConfig := range ccy.Vcenter {
+		cfg.VirtualCenter[keyVcConfig] = &VirtualCenterConfig{
+			User:              valVcConfig.User,
+			Password:          valVcConfig.Password,
+			TenantRef:         valVcConfig.TenantRef,
+			VCenterIP:         valVcConfig.VCenterIP,
+			VCenterPort:       fmt.Sprint(valVcConfig.VCenterPort),
+			InsecureFlag:      valVcConfig.InsecureFlag,
+			Datacenters:       strings.Join(valVcConfig.Datacenters, ","),
+			RoundTripperCount: valVcConfig.RoundTripperCount,
+			CAFile:            valVcConfig.CAFile,
+			Thumbprint:        valVcConfig.Thumbprint,
+			SecretRef:         valVcConfig.SecretRef,
+			SecretName:        valVcConfig.SecretName,
+			SecretNamespace:   valVcConfig.SecretNamespace,
+			IPFamilyPriority:  valVcConfig.IPFamilyPriority,
+		}
+	}
+
+	cfg.Labels.Region = ccy.Labels.Region
+	cfg.Labels.Zone = ccy.Labels.Zone
+
+	return cfg
+}
+
+// isSecretInfoProvided returns true if k8s secret is set or using generic CO secret method.
+// If both k8s secret and generic CO both are true, we don't know which to use, so return false.
+func (ccy *CommonConfigYAML) isSecretInfoProvided() bool {
+	return (ccy.Global.SecretName != "" && ccy.Global.SecretNamespace != "" && ccy.Global.SecretsDirectory == "") ||
+		(ccy.Global.SecretName == "" && ccy.Global.SecretNamespace == "" && ccy.Global.SecretsDirectory != "")
+}
+
+// isSecretInfoProvided returns true if the secret per VC has been configured
+func (vccy *VirtualCenterConfigYAML) isSecretInfoProvided() bool {
+	return vccy.SecretName != "" && vccy.SecretNamespace != ""
+}
+
+func (ccy *CommonConfigYAML) validateConfig() error {
+	//Fix default global values
+	if ccy.Global.RoundTripperCount == 0 {
+		ccy.Global.RoundTripperCount = DefaultRoundTripperCount
+	}
+	if ccy.Global.VCenterPort == 0 {
+		ccy.Global.VCenterPort = DefaultVCenterPort
+	}
+	if ccy.Global.APIBinding == "" {
+		ccy.Global.APIBinding = DefaultAPIBinding
+	}
+	if len(ccy.Global.IPFamilyPriority) == 0 {
+		ccy.Global.IPFamilyPriority = []string{DefaultIPFamily}
+	}
+
+	// Create a single instance of VSphereInstance for the Global VCenterIP if the
+	// VirtualCenter does not already exist in the map
+	if ccy.Global.VCenterIP != "" && ccy.Vcenter[ccy.Global.VCenterIP] == nil {
+		ccy.Vcenter[ccy.Global.VCenterIP] = &VirtualCenterConfigYAML{
+			User:              ccy.Global.User,
+			Password:          ccy.Global.Password,
+			TenantRef:         ccy.Global.VCenterIP,
+			VCenterIP:         ccy.Global.VCenterIP,
+			VCenterPort:       ccy.Global.VCenterPort,
+			InsecureFlag:      ccy.Global.InsecureFlag,
+			Datacenters:       ccy.Global.Datacenters,
+			RoundTripperCount: ccy.Global.RoundTripperCount,
+			CAFile:            ccy.Global.CAFile,
+			Thumbprint:        ccy.Global.Thumbprint,
+			SecretRef:         DefaultCredentialManager,
+			SecretName:        ccy.Global.SecretName,
+			SecretNamespace:   ccy.Global.SecretNamespace,
+			IPFamilyPriority:  ccy.Global.IPFamilyPriority,
+		}
+	}
+
+	// Must have at least one vCenter defined
+	if len(ccy.Vcenter) == 0 {
+		klog.Error(ErrMissingVCenter)
+		return ErrMissingVCenter
+	}
+
+	// vsphere.conf is no longer supported in the old format.
+	for tenantRef, vcConfig := range ccy.Vcenter {
+		klog.V(4).Infof("Initializing vc server %s", tenantRef)
+		if vcConfig.VCenterIP == "" {
+			klog.Error(ErrInvalidVCenterIP)
+			return ErrInvalidVCenterIP
+		}
+
+		// in the YAML-based config, the tenant ref is required in the config
+		vcConfig.TenantRef = tenantRef
+
+		if !ccy.isSecretInfoProvided() && !vcConfig.isSecretInfoProvided() {
+			if vcConfig.User == "" {
+				vcConfig.User = ccy.Global.User
+				if vcConfig.User == "" {
+					klog.Errorf("vcConfig.User is empty for vc %s!", tenantRef)
+					return ErrUsernameMissing
+				}
+			}
+			if vcConfig.Password == "" {
+				vcConfig.Password = ccy.Global.Password
+				if vcConfig.Password == "" {
+					klog.Errorf("vcConfig.Password is empty for vc %s!", tenantRef)
+					return ErrPasswordMissing
+				}
+			}
+		} else if ccy.isSecretInfoProvided() && !vcConfig.isSecretInfoProvided() {
+			vcConfig.SecretRef = DefaultCredentialManager
+		} else if vcConfig.isSecretInfoProvided() {
+			vcConfig.SecretRef = vcConfig.SecretNamespace + "/" + vcConfig.SecretName
+		}
+
+		if vcConfig.VCenterPort == 0 {
+			vcConfig.VCenterPort = ccy.Global.VCenterPort
+		}
+
+		if len(vcConfig.Datacenters) == 0 {
+			if len(ccy.Global.Datacenters) != 0 {
+				vcConfig.Datacenters = ccy.Global.Datacenters
+			}
+		}
+		if vcConfig.RoundTripperCount == 0 {
+			vcConfig.RoundTripperCount = ccy.Global.RoundTripperCount
+		}
+		if vcConfig.CAFile == "" {
+			vcConfig.CAFile = ccy.Global.CAFile
+		}
+		if vcConfig.Thumbprint == "" {
+			vcConfig.Thumbprint = ccy.Global.Thumbprint
+		}
+
+		if len(vcConfig.IPFamilyPriority) == 0 {
+			vcConfig.IPFamilyPriority = ccy.Global.IPFamilyPriority
+		}
+
+		insecure := vcConfig.InsecureFlag
+		if !insecure {
+			vcConfig.InsecureFlag = ccy.Global.InsecureFlag
+		}
+	}
+
+	return nil
+}
+
+// ReadRawConfigYAML parses vSphere cloud config file and stores it into ConfigYAML
+func ReadRawConfigYAML(byConfig []byte) (*CommonConfigYAML, error) {
+	if len(byConfig) == 0 {
+		klog.Errorf("Invalid YAML file")
+		return nil, fmt.Errorf("Invalid YAML file")
+	}
+
+	cfg := CommonConfigYAML{
+		Vcenter: make(map[string]*VirtualCenterConfigYAML),
+	}
+
+	if err := yaml.Unmarshal(byConfig, &cfg); err != nil {
+		klog.Errorf("Unmarshal failed: %s", err)
+		return nil, err
+	}
+
+	err := cfg.validateConfig()
+	if err != nil {
+		klog.Errorf("validateConfig failed: %s", err)
+		return nil, err
+	}
+
+	return &cfg, nil
+}
+
+// ReadConfigYAML parses vSphere cloud config file and stores it into Config
+func ReadConfigYAML(byConfig []byte) (*Config, error) {
+	cfg, err := ReadRawConfigYAML(byConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg.CreateConfig(), nil
+}

--- a/third_party/cloud-provider-vsphere/pkg/common/config/consts_and_errors.go
+++ b/third_party/cloud-provider-vsphere/pkg/common/config/consts_and_errors.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"errors"
+)
+
+const (
+	// DefaultRoundTripperCount is the number of allowed round trips
+	// before an error is returned.
+	DefaultRoundTripperCount uint = 3
+
+	// DefaultAPIBinding is the default ADDRESS:PORT binding used for
+	// exposing the API service.
+	DefaultAPIBinding string = ":43001"
+
+	// DefaultVCenterPortStr is the default port used to access vCenter in string form
+	DefaultVCenterPortStr string = "443"
+	// DefaultVCenterPort is the default port used to access vCenter in uint form
+	DefaultVCenterPort uint = 443
+
+	// DefaultSecretDirectory is the default path to the secrets directory.
+	DefaultSecretDirectory string = "/etc/cloud/secrets"
+
+	// IPv6Family string representation for IPv6
+	IPv6Family = "ipv6"
+	// IPv4Family string representation for IPv4
+	IPv4Family = "ipv4"
+
+	// DefaultIPFamily is the default IP addressing to use for networking
+	DefaultIPFamily = IPv4Family
+
+	// DefaultCredentialManager used for the Global CredMgr/Lister
+	DefaultCredentialManager string = "Global"
+)
+
+var (
+	// ErrUsernameMissing is returned when the provided username is empty.
+	ErrUsernameMissing = errors.New("Username is missing")
+
+	// ErrPasswordMissing is returned when the provided password is empty.
+	ErrPasswordMissing = errors.New("Password is missing")
+
+	// ErrInvalidVCenterIP is returned when the provided vCenter IP address is
+	// missing from the provided configuration.
+	ErrInvalidVCenterIP = errors.New("vsphere.conf does not have the VirtualCenter IP address specified")
+
+	// ErrMissingVCenter is returned when the provided configuration does not
+	// define any vCenters.
+	ErrMissingVCenter = errors.New("No Virtual Center hosts defined")
+
+	// ErrInvalidIPFamilyType is returned when an invalid IPFamily type is encountered
+	ErrInvalidIPFamilyType = errors.New("Invalid IP Family type")
+)

--- a/third_party/cloud-provider-vsphere/pkg/common/config/types_common.go
+++ b/third_party/cloud-provider-vsphere/pkg/common/config/types_common.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+/*
+	TODO:
+	When the INI based cloud-config is deprecated. This file should be deleted and
+	the structs in types_yaml.go will be renamed to replace the ones in this file.
+*/
+
+// Global struct
+type Global struct {
+	// vCenter username.
+	User string
+	// vCenter password in clear text.
+	Password string
+	// Deprecated. Use VirtualCenter to specify multiple vCenter Servers.
+	// vCenter IP.
+	VCenterIP string
+	// vCenter port.
+	VCenterPort string
+	// True if vCenter uses self-signed cert.
+	InsecureFlag bool
+	// Datacenter in which VMs are located.
+	Datacenters string
+	// Soap round tripper count (retries = RoundTripper - 1)
+	RoundTripperCount uint
+	// Specifies the path to a CA certificate in PEM format. Optional; if not
+	// configured, the system's CA certificates will be used.
+	CAFile string
+	// Thumbprint of the VCenter's certificate thumbprint
+	Thumbprint string
+	// Name of the secret were vCenter credentials are present.
+	SecretName string
+	// Secret Namespace where secret will be present that has vCenter credentials.
+	SecretNamespace string
+	// Secret directory in the event that:
+	// 1) we don't want to use the k8s API to listen for changes to secrets
+	// 2) we are not in a k8s env, namely DC/OS, since CSI is CO agnostic
+	// Default: /etc/cloud/credentials
+	SecretsDirectory string
+}
+
+// VirtualCenterConfig struct
+type VirtualCenterConfig struct {
+	// vCenter username.
+	User string
+	// vCenter password in clear text.
+	Password string
+	// TenantRef (intentionally not exposed via the config) is a unique tenant ref to
+	// be used in place of the vcServer as the primary connection key. If one label is set,
+	// all virtual center configs must have a unique label.
+	TenantRef string
+	// vCenterIP - If this field in the config is set, it is assumed then that value in [VirtualCenter "<value>"]
+	// is now the TenantRef above and this field is the actual VCenterIP. Otherwise for backward
+	// compatibility, the value by default is the IP or FQDN of the vCenter Server.
+	VCenterIP string
+	// vCenter port.
+	VCenterPort string
+	// True if vCenter uses self-signed cert.
+	InsecureFlag bool
+	// Datacenter in which VMs are located.
+	Datacenters string
+	// Soap round tripper count (retries = RoundTripper - 1)
+	RoundTripperCount uint
+	// Specifies the path to a CA certificate in PEM format. Optional; if not
+	// configured, the system's CA certificates will be used.
+	CAFile string
+	// Thumbprint of the VCenter's certificate thumbprint
+	Thumbprint string
+	// SecretRef (intentionally not exposed via the config) is a key to identify which
+	// InformerManager holds the secret
+	SecretRef string
+	// Name of the secret where vCenter credentials are present.
+	SecretName string
+	// Namespace where the secret will be present containing vCenter credentials.
+	SecretNamespace string
+	// IP Family enables the ability to support IPv4 or IPv6
+	// Supported values are:
+	// ipv4 - IPv4 addresses only (Default)
+	// ipv6 - IPv6 addresses only
+	IPFamilyPriority []string
+}
+
+// Labels struct
+type Labels struct {
+	// Zone describes a zone
+	Zone string
+	// Region describes a region
+	Region string
+}
+
+// Config is used to read and store information from the cloud configuration file
+type Config struct {
+	// Global settings
+	Global Global
+
+	// Virtual Center configurations
+	VirtualCenter map[string]*VirtualCenterConfig
+
+	// Tag categories and tags which correspond to "built-in node labels: zones and region"
+	Labels Labels
+}

--- a/third_party/cloud-provider-vsphere/pkg/common/config/types_ini_legacy.go
+++ b/third_party/cloud-provider-vsphere/pkg/common/config/types_ini_legacy.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+/*
+	TODO:
+	When the INI based cloud-config is deprecated. This file should be deleted.
+*/
+
+// GlobalINI are global values
+type GlobalINI struct {
+	// vCenter username.
+	User string `gcfg:"user"`
+	// vCenter password in clear text.
+	Password string `gcfg:"password"`
+	// Deprecated. Use VirtualCenter to specify multiple vCenter Servers.
+	// vCenter IP.
+	VCenterIP string `gcfg:"server"`
+	// vCenter port.
+	VCenterPort string `gcfg:"port"`
+	// True if vCenter uses self-signed cert.
+	InsecureFlag bool `gcfg:"insecure-flag"`
+	// Datacenter in which VMs are located.
+	Datacenters string `gcfg:"datacenters"`
+	// Soap round tripper count (retries = RoundTripper - 1)
+	RoundTripperCount uint `gcfg:"soap-roundtrip-count"`
+	// Specifies the path to a CA certificate in PEM format. Optional; if not
+	// configured, the system's CA certificates will be used.
+	CAFile string `gcfg:"ca-file"`
+	// Thumbprint of the VCenter's certificate thumbprint
+	Thumbprint string `gcfg:"thumbprint"`
+	// Name of the secret were vCenter credentials are present.
+	SecretName string `gcfg:"secret-name"`
+	// Secret Namespace where secret will be present that has vCenter credentials.
+	SecretNamespace string `gcfg:"secret-namespace"`
+	// Secret directory in the event that:
+	// 1) we don't want to use the k8s API to listen for changes to secrets
+	// 2) we are not in a k8s env, namely DC/OS, since CSI is CO agnostic
+	// Default: /etc/cloud/credentials
+	SecretsDirectory string `gcfg:"secrets-directory"`
+	// Disable the vSphere CCM API
+	// Default: true
+	APIDisable bool `gcfg:"api-disable"`
+	// Configurable vSphere CCM API port
+	// Default: 43001
+	APIBinding string `gcfg:"api-binding"`
+	// IP Family enables the ability to support IPv4 or IPv6
+	// Supported values are:
+	// ipv4 - IPv4 addresses only (Default)
+	// ipv6 - IPv6 addresses only
+	IPFamily string `gcfg:"ip-family"`
+}
+
+// VirtualCenterConfigINI contains information used to access a remote vCenter
+// endpoint.
+type VirtualCenterConfigINI struct {
+	// vCenter username.
+	User string `gcfg:"user"`
+	// vCenter password in clear text.
+	Password string `gcfg:"password"`
+	// TenantRef (intentionally not exposed via the config) is a unique tenant ref to
+	// be used in place of the vcServer as the primary connection key. If one label is set,
+	// all virtual center configs must have a unique label.
+	TenantRef string
+	// vCenterIP - If this field in the config is set, it is assumed then that value in [VirtualCenter "<value>"]
+	// is now the TenantRef above and this field is the actual VCenterIP. Otherwise for backward
+	// compatibility, the value by default is the IP or FQDN of the vCenter Server.
+	VCenterIP string `gcfg:"server"`
+	// vCenter port.
+	VCenterPort string `gcfg:"port"`
+	// True if vCenter uses self-signed cert.
+	InsecureFlag bool `gcfg:"insecure-flag"`
+	// Datacenter in which VMs are located.
+	Datacenters string `gcfg:"datacenters"`
+	// Soap round tripper count (retries = RoundTripper - 1)
+	RoundTripperCount uint `gcfg:"soap-roundtrip-count"`
+	// Specifies the path to a CA certificate in PEM format. Optional; if not
+	// configured, the system's CA certificates will be used.
+	CAFile string `gcfg:"ca-file"`
+	// Thumbprint of the VCenter's certificate thumbprint
+	Thumbprint string `gcfg:"thumbprint"`
+	// SecretRef (intentionally not exposed via the config) is a key to identify which
+	// InformerManager holds the secret
+	SecretRef string
+	// Name of the secret where vCenter credentials are present.
+	SecretName string `gcfg:"secret-name"`
+	// Namespace where the secret will be present containing vCenter credentials.
+	SecretNamespace string `gcfg:"secret-namespace"`
+	// IP Family enables the ability to support IPv4 or IPv6
+	// Supported values are:
+	// ipv4 - IPv4 addresses only (Default)
+	// ipv6 - IPv6 addresses only
+	IPFamily string `gcfg:"ip-family"`
+	// IPFamilyPriority (intentionally not exposed via the config) the list/priority of IP versions
+	IPFamilyPriority []string
+}
+
+// LabelsINI tags categories and tags which correspond to "built-in node labels: zones and region"
+type LabelsINI struct {
+	Zone   string `gcfg:"zone"`
+	Region string `gcfg:"region"`
+}
+
+// CommonConfigINI is used to read and store information from the cloud configuration file
+type CommonConfigINI struct {
+	// Global values...
+	Global GlobalINI
+
+	// Virtual Center configurations
+	VirtualCenter map[string]*VirtualCenterConfigINI
+
+	// Tag categories and tags which correspond to "built-in node labels: zones and region"
+	Labels LabelsINI
+}

--- a/third_party/cloud-provider-vsphere/pkg/common/config/types_yaml.go
+++ b/third_party/cloud-provider-vsphere/pkg/common/config/types_yaml.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+/*
+	TODO:
+	When the INI based cloud-config is deprecated, this file should be renamed
+	from types_yaml.go to types.go and the structs within this file should be named:
+
+	GlobalYAML -> Global
+	VirtualCenterConfigYAML -> VirtualCenterConfig
+	LabelsYAML -> Labels
+	ConfigYAML -> Config
+*/
+
+// GlobalYAML are global values
+type GlobalYAML struct {
+	// vCenter username.
+	User string `yaml:"user"`
+	// vCenter password in clear text.
+	Password string `yaml:"password"`
+	// Deprecated. Use VirtualCenter to specify multiple vCenter Servers.
+	// vCenter IP.
+	VCenterIP string `yaml:"server"`
+	// vCenter port.
+	VCenterPort uint `yaml:"port"`
+	// True if vCenter uses self-signed cert.
+	InsecureFlag bool `yaml:"insecureFlag"`
+	// Datacenter in which VMs are located.
+	Datacenters []string `yaml:"datacenters"`
+	// Soap round tripper count (retries = RoundTripper - 1)
+	RoundTripperCount uint `yaml:"soapRoundtripCount"`
+	// Specifies the path to a CA certificate in PEM format. Optional; if not
+	// configured, the system's CA certificates will be used.
+	CAFile string `yaml:"caFile"`
+	// Thumbprint of the VCenter's certificate thumbprint
+	Thumbprint string `yaml:"thumbprint"`
+	// Name of the secret were vCenter credentials are present.
+	SecretName string `yaml:"secretName"`
+	// Secret Namespace where secret will be present that has vCenter credentials.
+	SecretNamespace string `yaml:"secretNamespace"`
+	// Secret directory in the event that:
+	// 1) we don't want to use the k8s API to listen for changes to secrets
+	// 2) we are not in a k8s env, namely DC/OS, since CSI is CO agnostic
+	// Default: /etc/cloud/credentials
+	SecretsDirectory string `yaml:"secretsDirectory"`
+	// Disable the vSphere CCM API
+	// Default: true
+	APIDisable bool `yaml:"apiDisable"`
+	// Configurable vSphere CCM API port
+	// Default: 43001
+	APIBinding string `yaml:"apiBinding"`
+	// IP Family enables the ability to support IPv4 or IPv6
+	// Supported values are:
+	// ipv4 - IPv4 addresses only (Default)
+	// ipv6 - IPv6 addresses only
+	IPFamilyPriority []string `yaml:"ipFamily"`
+}
+
+// VirtualCenterConfigYAML contains information used to access a remote vCenter
+// endpoint.
+type VirtualCenterConfigYAML struct {
+	// vCenter username.
+	User string `yaml:"user"`
+	// vCenter password in clear text.
+	Password string `yaml:"password"`
+	// TenantRef (intentionally not exposed via the config) is a unique tenant ref to
+	// be used in place of the vcServer as the primary connection key. If one label is set,
+	// all virtual center configs must have a unique label.
+	TenantRef string
+	// vCenterIP - If this field in the config is set, it is assumed then that value in [VirtualCenter "<value>"]
+	// is now the TenantRef above and this field is the actual VCenterIP. Otherwise for backward
+	// compatibility, the value by default is the IP or FQDN of the vCenter Server.
+	VCenterIP string `yaml:"server"`
+	// vCenter port.
+	VCenterPort uint `yaml:"port"`
+	// True if vCenter uses self-signed cert.
+	InsecureFlag bool `yaml:"insecureFlag"`
+	// Datacenter in which VMs are located.
+	Datacenters []string `yaml:"datacenters"`
+	// Soap round tripper count (retries = RoundTripper - 1)
+	RoundTripperCount uint `yaml:"soapRoundtripCount"`
+	// Specifies the path to a CA certificate in PEM format. Optional; if not
+	// configured, the system's CA certificates will be used.
+	CAFile string `yaml:"caFile"`
+	// Thumbprint of the VCenter's certificate thumbprint
+	Thumbprint string `yaml:"thumbprint"`
+	// SecretRef (intentionally not exposed via the config) is a key to identify which
+	// InformerManager holds the secret
+	SecretRef string
+	// Name of the secret where vCenter credentials are present.
+	SecretName string `yaml:"secretName"`
+	// Namespace where the secret will be present containing vCenter credentials.
+	SecretNamespace string `yaml:"secretNamespace"`
+	// IP Family enables the ability to support IPv4 or IPv6
+	// Supported values are:
+	// ipv4 - IPv4 addresses only (Default)
+	// ipv6 - IPv6 addresses only
+	IPFamilyPriority []string `yaml:"ipFamily"`
+}
+
+// LabelsYAML tags categories and tags which correspond to "built-in node labels: zones and region"
+type LabelsYAML struct {
+	Zone   string `yaml:"zone"`
+	Region string `yaml:"region"`
+}
+
+// CommonConfigYAML is used to read and store information from the cloud configuration file
+type CommonConfigYAML struct {
+	// Global values...
+	Global GlobalYAML
+
+	// Virtual Center configurations
+	Vcenter map[string]*VirtualCenterConfigYAML
+
+	// Tag categories and tags which correspond to "built-in node labels: zones and region"
+	Labels LabelsYAML
+}

--- a/vendor/github.com/imdario/mergo/.deepsource.toml
+++ b/vendor/github.com/imdario/mergo/.deepsource.toml
@@ -1,0 +1,12 @@
+version = 1
+
+test_patterns = [
+  "*_test.go"
+]
+
+[[analyzers]]
+name = "go"
+enabled = true
+
+  [analyzers.meta]
+  import_path = "github.com/imdario/mergo"

--- a/vendor/github.com/imdario/mergo/.travis.yml
+++ b/vendor/github.com/imdario/mergo/.travis.yml
@@ -1,7 +1,12 @@
 language: go
+arch:
+    - amd64
+    - ppc64le
 install:
   - go get -t
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/mattn/goveralls
 script:
+  - go test -race -v ./...
+after_script:
   - $HOME/gopath/bin/goveralls -service=travis-ci -repotoken $COVERALLS_TOKEN

--- a/vendor/github.com/imdario/mergo/CONTRIBUTING.md
+++ b/vendor/github.com/imdario/mergo/CONTRIBUTING.md
@@ -1,0 +1,112 @@
+<!-- omit in toc -->
+# Contributing to mergo
+
+First off, thanks for taking the time to contribute! ❤️
+
+All types of contributions are encouraged and valued. See the [Table of Contents](#table-of-contents) for different ways to help and details about how this project handles them. Please make sure to read the relevant section before making your contribution. It will make it a lot easier for us maintainers and smooth out the experience for all involved. The community looks forward to your contributions. 🎉
+
+> And if you like the project, but just don't have time to contribute, that's fine. There are other easy ways to support the project and show your appreciation, which we would also be very happy about:
+> - Star the project
+> - Tweet about it
+> - Refer this project in your project's readme
+> - Mention the project at local meetups and tell your friends/colleagues
+
+<!-- omit in toc -->
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [I Have a Question](#i-have-a-question)
+- [I Want To Contribute](#i-want-to-contribute)
+- [Reporting Bugs](#reporting-bugs)
+- [Suggesting Enhancements](#suggesting-enhancements)
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by the
+[mergo Code of Conduct](https://github.com/imdario/mergoblob/master/CODE_OF_CONDUCT.md).
+By participating, you are expected to uphold this code. Please report unacceptable behavior
+to <>.
+
+
+## I Have a Question
+
+> If you want to ask a question, we assume that you have read the available [Documentation](https://pkg.go.dev/github.com/imdario/mergo).
+
+Before you ask a question, it is best to search for existing [Issues](https://github.com/imdario/mergo/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
+
+If you then still feel the need to ask a question and need clarification, we recommend the following:
+
+- Open an [Issue](https://github.com/imdario/mergo/issues/new).
+- Provide as much context as you can about what you're running into.
+- Provide project and platform versions (nodejs, npm, etc), depending on what seems relevant.
+
+We will then take care of the issue as soon as possible.
+
+## I Want To Contribute
+
+> ### Legal Notice <!-- omit in toc -->
+> When contributing to this project, you must agree that you have authored 100% of the content, that you have the necessary rights to the content and that the content you contribute may be provided under the project license.
+
+### Reporting Bugs
+
+<!-- omit in toc -->
+#### Before Submitting a Bug Report
+
+A good bug report shouldn't leave others needing to chase you up for more information. Therefore, we ask you to investigate carefully, collect information and describe the issue in detail in your report. Please complete the following steps in advance to help us fix any potential bug as fast as possible.
+
+- Make sure that you are using the latest version.
+- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](). If you are looking for support, you might want to check [this section](#i-have-a-question)).
+- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/imdario/mergoissues?q=label%3Abug).
+- Also make sure to search the internet (including Stack Overflow) to see if users outside of the GitHub community have discussed the issue.
+- Collect information about the bug:
+- Stack trace (Traceback)
+- OS, Platform and Version (Windows, Linux, macOS, x86, ARM)
+- Version of the interpreter, compiler, SDK, runtime environment, package manager, depending on what seems relevant.
+- Possibly your input and the output
+- Can you reliably reproduce the issue? And can you also reproduce it with older versions?
+
+<!-- omit in toc -->
+#### How Do I Submit a Good Bug Report?
+
+> You must never report security related issues, vulnerabilities or bugs including sensitive information to the issue tracker, or elsewhere in public. Instead sensitive bugs must be sent by email to .
+<!-- You may add a PGP key to allow the messages to be sent encrypted as well. -->
+
+We use GitHub issues to track bugs and errors. If you run into an issue with the project:
+
+- Open an [Issue](https://github.com/imdario/mergo/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
+- Explain the behavior you would expect and the actual behavior.
+- Please provide as much context as possible and describe the *reproduction steps* that someone else can follow to recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem and create a reduced test case.
+- Provide the information you collected in the previous section.
+
+Once it's filed:
+
+- The project team will label the issue accordingly.
+- A team member will try to reproduce the issue with your provided steps. If there are no reproduction steps or no obvious way to reproduce the issue, the team will ask you for those steps and mark the issue as `needs-repro`. Bugs with the `needs-repro` tag will not be addressed until they are reproduced.
+- If the team is able to reproduce the issue, it will be marked `needs-fix`, as well as possibly other tags (such as `critical`), and the issue will be left to be implemented by someone.
+
+### Suggesting Enhancements
+
+This section guides you through submitting an enhancement suggestion for mergo, **including completely new features and minor improvements to existing functionality**. Following these guidelines will help maintainers and the community to understand your suggestion and find related suggestions.
+
+<!-- omit in toc -->
+#### Before Submitting an Enhancement
+
+- Make sure that you are using the latest version.
+- Read the [documentation]() carefully and find out if the functionality is already covered, maybe by an individual configuration.
+- Perform a [search](https://github.com/imdario/mergo/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
+- Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on/plugin library.
+
+<!-- omit in toc -->
+#### How Do I Submit a Good Enhancement Suggestion?
+
+Enhancement suggestions are tracked as [GitHub issues](https://github.com/imdario/mergo/issues).
+
+- Use a **clear and descriptive title** for the issue to identify the suggestion.
+- Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
+- **Describe the current behavior** and **explain which behavior you expected to see instead** and why. At this point you can also tell which alternatives do not work for you.
+- You may want to **include screenshots and animated GIFs** which help you demonstrate the steps or point out the part which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux. <!-- this should only be included if the project has a GUI -->
+- **Explain why this enhancement would be useful** to most mergo users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
+
+<!-- omit in toc -->
+## Attribution
+This guide is based on the **contributing-gen**. [Make your own](https://github.com/bttger/contributing-gen)!

--- a/vendor/github.com/imdario/mergo/README.md
+++ b/vendor/github.com/imdario/mergo/README.md
@@ -1,49 +1,59 @@
 # Mergo
 
-A helper to merge structs and maps in Golang. Useful for configuration default values, avoiding messy if-statements.
-
-Also a lovely [comune](http://en.wikipedia.org/wiki/Mergo) (municipality) in the Province of Ancona in the Italian region of Marche.
-
-## Status
-
-It is ready for production use. [It is used in several projects by Docker, Google, The Linux Foundation, VMWare, Shopify, etc](https://github.com/imdario/mergo#mergo-in-the-wild).
-
 [![GoDoc][3]][4]
-[![GoCard][5]][6]
+[![GitHub release][5]][6]
+[![GoCard][7]][8]
 [![Build Status][1]][2]
-[![Coverage Status][7]][8]
-[![Sourcegraph][9]][10]
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fimdario%2Fmergo.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fimdario%2Fmergo?ref=badge_shield)
+[![Coverage Status][9]][10]
+[![Sourcegraph][11]][12]
+[![FOSSA Status][13]][14]
+[![Become my sponsor][15]][16]
+[![Tidelift][17]][18]
 
 [1]: https://travis-ci.org/imdario/mergo.png
 [2]: https://travis-ci.org/imdario/mergo
 [3]: https://godoc.org/github.com/imdario/mergo?status.svg
 [4]: https://godoc.org/github.com/imdario/mergo
-[5]: https://goreportcard.com/badge/imdario/mergo
-[6]: https://goreportcard.com/report/github.com/imdario/mergo
-[7]: https://coveralls.io/repos/github/imdario/mergo/badge.svg?branch=master
-[8]: https://coveralls.io/github/imdario/mergo?branch=master
-[9]: https://sourcegraph.com/github.com/imdario/mergo/-/badge.svg
-[10]: https://sourcegraph.com/github.com/imdario/mergo?badge
+[5]: https://img.shields.io/github/release/imdario/mergo.svg
+[6]: https://github.com/imdario/mergo/releases
+[7]: https://goreportcard.com/badge/imdario/mergo
+[8]: https://goreportcard.com/report/github.com/imdario/mergo
+[9]: https://coveralls.io/repos/github/imdario/mergo/badge.svg?branch=master
+[10]: https://coveralls.io/github/imdario/mergo?branch=master
+[11]: https://sourcegraph.com/github.com/imdario/mergo/-/badge.svg
+[12]: https://sourcegraph.com/github.com/imdario/mergo?badge
+[13]: https://app.fossa.io/api/projects/git%2Bgithub.com%2Fimdario%2Fmergo.svg?type=shield
+[14]: https://app.fossa.io/projects/git%2Bgithub.com%2Fimdario%2Fmergo?ref=badge_shield
+[15]: https://img.shields.io/github/sponsors/imdario
+[16]: https://github.com/sponsors/imdario
+[17]: https://tidelift.com/badges/package/go/github.com%2Fimdario%2Fmergo
+[18]: https://tidelift.com/subscription/pkg/go-github.com-imdario-mergo
 
-### Latest release
+A helper to merge structs and maps in Golang. Useful for configuration default values, avoiding messy if-statements.
 
-[Release v0.3.7](https://github.com/imdario/mergo/releases/tag/v0.3.7).
+Mergo merges same-type structs and maps by setting default values in zero-value fields. Mergo won't merge unexported (private) fields. It will do recursively any exported one. It also won't merge structs inside maps (because they are not addressable using Go reflection).
+
+Also a lovely [comune](http://en.wikipedia.org/wiki/Mergo) (municipality) in the Province of Ancona in the Italian region of Marche.
+
+## Status
+
+It is ready for production use. [It is used in several projects by Docker, Google, The Linux Foundation, VMWare, Shopify, Microsoft, etc](https://github.com/imdario/mergo#mergo-in-the-wild).
 
 ### Important note
 
-Please keep in mind that in [0.3.2](//github.com/imdario/mergo/releases/tag/0.3.2) Mergo changed `Merge()`and `Map()` signatures to support [transformers](#transformers). An optional/variadic argument has been added, so it won't break existing code.
+Please keep in mind that a problematic PR broke [0.3.9](//github.com/imdario/mergo/releases/tag/0.3.9). I reverted it in [0.3.10](//github.com/imdario/mergo/releases/tag/0.3.10), and I consider it stable but not bug-free. Also, this version adds support for go modules.
 
-If you were using Mergo **before** April 6th 2015, please check your project works as intended after updating your local copy with ```go get -u github.com/imdario/mergo```. I apologize for any issue caused by its previous behavior and any future bug that Mergo could cause (I hope it won't!) in existing projects after the change (release 0.2.0).
+Keep in mind that in [0.3.2](//github.com/imdario/mergo/releases/tag/0.3.2), Mergo changed `Merge()`and `Map()` signatures to support [transformers](#transformers). I added an optional/variadic argument so that it won't break the existing code.
+
+If you were using Mergo before April 6th, 2015, please check your project works as intended after updating your local copy with ```go get -u github.com/imdario/mergo```. I apologize for any issue caused by its previous behavior and any future bug that Mergo could cause in existing projects after the change (release 0.2.0).
 
 ### Donations
 
-If Mergo is useful to you, consider buying me a coffee, a beer or making a monthly donation so I can keep building great free software. :heart_eyes:
+If Mergo is useful to you, consider buying me a coffee, a beer, or making a monthly donation to allow me to keep building great free software. :heart_eyes:
 
 <a href='https://ko-fi.com/B0B58839' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://az743702.vo.msecnd.net/cdn/kofi1.png?v=0' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
-[![Beerpay](https://beerpay.io/imdario/mergo/badge.svg)](https://beerpay.io/imdario/mergo)
-[![Beerpay](https://beerpay.io/imdario/mergo/make-wish.svg)](https://beerpay.io/imdario/mergo)
 <a href="https://liberapay.com/dario/donate"><img alt="Donate using Liberapay" src="https://liberapay.com/assets/widgets/donate.svg"></a>
+<a href='https://github.com/sponsors/imdario' target='_blank'><img alt="Become my sponsor" src="https://img.shields.io/github/sponsors/imdario?style=for-the-badge" /></a>
 
 ### Mergo in the wild
 
@@ -87,8 +97,11 @@ If Mergo is useful to you, consider buying me a coffee, a beer or making a month
 - [mantasmatelis/whooplist-server](https://github.com/mantasmatelis/whooplist-server)
 - [jnuthong/item_search](https://github.com/jnuthong/item_search)
 - [bukalapak/snowboard](https://github.com/bukalapak/snowboard)
+- [containerssh/containerssh](https://github.com/containerssh/containerssh)
+- [goreleaser/goreleaser](https://github.com/goreleaser/goreleaser)
+- [tjpnz/structbot](https://github.com/tjpnz/structbot)
 
-## Installation
+## Install
 
     go get github.com/imdario/mergo
 
@@ -99,7 +112,7 @@ If Mergo is useful to you, consider buying me a coffee, a beer or making a month
 
 ## Usage
 
-You can only merge same-type structs with exported fields initialized as zero value of their type and same-types maps. Mergo won't merge unexported (private) fields but will do recursively any exported one. It won't merge empty structs value as [they are not considered zero values](https://golang.org/ref/spec#The_zero_value) either. Also maps will be merged recursively except for structs inside maps (because they are not addressable using Go reflection).
+You can only merge same-type structs with exported fields initialized as zero value of their type and same-types maps. Mergo won't merge unexported (private) fields but will do recursively any exported one. It won't merge empty structs value as [they are zero values](https://golang.org/ref/spec#The_zero_value) too. Also, maps will be merged recursively except for structs inside maps (because they are not addressable using Go reflection).
 
 ```go
 if err := mergo.Merge(&dst, src); err != nil {
@@ -125,9 +138,7 @@ if err := mergo.Map(&dst, srcMap); err != nil {
 
 Warning: if you map a struct to map, it won't do it recursively. Don't expect Mergo to map struct members of your struct as `map[string]interface{}`. They will be just assigned as values.
 
-More information and examples in [godoc documentation](http://godoc.org/github.com/imdario/mergo).
-
-### Nice example
+Here is a nice example:
 
 ```go
 package main
@@ -159,7 +170,7 @@ func main() {
 
 Note: if test are failing due missing package, please execute:
 
-    go get gopkg.in/yaml.v2
+    go get gopkg.in/yaml.v3
 
 ### Transformers
 
@@ -175,10 +186,10 @@ import (
         "time"
 )
 
-type timeTransfomer struct {
+type timeTransformer struct {
 }
 
-func (t timeTransfomer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
+func (t timeTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
 	if typ == reflect.TypeOf(time.Time{}) {
 		return func(dst, src reflect.Value) error {
 			if dst.CanSet() {
@@ -202,13 +213,12 @@ type Snapshot struct {
 func main() {
 	src := Snapshot{time.Now()}
 	dest := Snapshot{}
-	mergo.Merge(&dest, src, mergo.WithTransformers(timeTransfomer{}))
+	mergo.Merge(&dest, src, mergo.WithTransformers(timeTransformer{}))
 	fmt.Println(dest)
 	// Will print
 	// { 2018-01-12 01:15:00 +0000 UTC m=+0.000000001 }
 }
 ```
-
 
 ## Contact me
 
@@ -217,18 +227,6 @@ If I can help you, you have an idea or you are using Mergo in your projects, don
 ## About
 
 Written by [Dario Castañé](http://dario.im).
-
-## Top Contributors
-
-[![0](https://sourcerer.io/fame/imdario/imdario/mergo/images/0)](https://sourcerer.io/fame/imdario/imdario/mergo/links/0)
-[![1](https://sourcerer.io/fame/imdario/imdario/mergo/images/1)](https://sourcerer.io/fame/imdario/imdario/mergo/links/1)
-[![2](https://sourcerer.io/fame/imdario/imdario/mergo/images/2)](https://sourcerer.io/fame/imdario/imdario/mergo/links/2)
-[![3](https://sourcerer.io/fame/imdario/imdario/mergo/images/3)](https://sourcerer.io/fame/imdario/imdario/mergo/links/3)
-[![4](https://sourcerer.io/fame/imdario/imdario/mergo/images/4)](https://sourcerer.io/fame/imdario/imdario/mergo/links/4)
-[![5](https://sourcerer.io/fame/imdario/imdario/mergo/images/5)](https://sourcerer.io/fame/imdario/imdario/mergo/links/5)
-[![6](https://sourcerer.io/fame/imdario/imdario/mergo/images/6)](https://sourcerer.io/fame/imdario/imdario/mergo/links/6)
-[![7](https://sourcerer.io/fame/imdario/imdario/mergo/images/7)](https://sourcerer.io/fame/imdario/imdario/mergo/links/7)
-
 
 ## License
 

--- a/vendor/github.com/imdario/mergo/SECURITY.md
+++ b/vendor/github.com/imdario/mergo/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.3.x   | :white_check_mark: |
+| < 0.3   | :x:                |
+
+## Security contact information
+
+To report a security vulnerability, please use the
+[Tidelift security contact](https://tidelift.com/security).
+Tidelift will coordinate the fix and disclosure.

--- a/vendor/github.com/imdario/mergo/doc.go
+++ b/vendor/github.com/imdario/mergo/doc.go
@@ -4,41 +4,140 @@
 // license that can be found in the LICENSE file.
 
 /*
-Package mergo merges same-type structs and maps by setting default values in zero-value fields.
+A helper to merge structs and maps in Golang. Useful for configuration default values, avoiding messy if-statements.
 
-Mergo won't merge unexported (private) fields but will do recursively any exported one. It also won't merge structs inside maps (because they are not addressable using Go reflection).
+Mergo merges same-type structs and maps by setting default values in zero-value fields. Mergo won't merge unexported (private) fields. It will do recursively any exported one. It also won't merge structs inside maps (because they are not addressable using Go reflection).
+
+Status
+
+It is ready for production use. It is used in several projects by Docker, Google, The Linux Foundation, VMWare, Shopify, etc.
+
+Important note
+
+Please keep in mind that a problematic PR broke 0.3.9. We reverted it in 0.3.10. We consider 0.3.10 as stable but not bug-free. . Also, this version adds suppot for go modules.
+
+Keep in mind that in 0.3.2, Mergo changed Merge() and Map() signatures to support transformers. We added an optional/variadic argument so that it won't break the existing code.
+
+If you were using Mergo before April 6th, 2015, please check your project works as intended after updating your local copy with go get -u github.com/imdario/mergo. I apologize for any issue caused by its previous behavior and any future bug that Mergo could cause in existing projects after the change (release 0.2.0).
+
+Install
+
+Do your usual installation procedure:
+
+    go get github.com/imdario/mergo
+
+    // use in your .go code
+    import (
+        "github.com/imdario/mergo"
+    )
 
 Usage
 
-From my own work-in-progress project:
+You can only merge same-type structs with exported fields initialized as zero value of their type and same-types maps. Mergo won't merge unexported (private) fields but will do recursively any exported one. It won't merge empty structs value as they are zero values too. Also, maps will be merged recursively except for structs inside maps (because they are not addressable using Go reflection).
 
-	type networkConfig struct {
-		Protocol string
-		Address string
-		ServerType string `json: "server_type"`
-		Port uint16
+	if err := mergo.Merge(&dst, src); err != nil {
+		// ...
 	}
 
-	type FssnConfig struct {
-		Network networkConfig
+Also, you can merge overwriting values using the transformer WithOverride.
+
+	if err := mergo.Merge(&dst, src, mergo.WithOverride); err != nil {
+		// ...
 	}
 
-	var fssnDefault = FssnConfig {
-		networkConfig {
-			"tcp",
-			"127.0.0.1",
-			"http",
-			31560,
-		},
+Additionally, you can map a map[string]interface{} to a struct (and otherwise, from struct to map), following the same restrictions as in Merge(). Keys are capitalized to find each corresponding exported field.
+
+	if err := mergo.Map(&dst, srcMap); err != nil {
+		// ...
 	}
 
-	// Inside a function [...]
+Warning: if you map a struct to map, it won't do it recursively. Don't expect Mergo to map struct members of your struct as map[string]interface{}. They will be just assigned as values.
 
-	if err := mergo.Merge(&config, fssnDefault); err != nil {
-		log.Fatal(err)
+Here is a nice example:
+
+	package main
+
+	import (
+		"fmt"
+		"github.com/imdario/mergo"
+	)
+
+	type Foo struct {
+		A string
+		B int64
 	}
 
-	// More code [...]
+	func main() {
+		src := Foo{
+			A: "one",
+			B: 2,
+		}
+		dest := Foo{
+			A: "two",
+		}
+		mergo.Merge(&dest, src)
+		fmt.Println(dest)
+		// Will print
+		// {two 2}
+	}
+
+Transformers
+
+Transformers allow to merge specific types differently than in the default behavior. In other words, now you can customize how some types are merged. For example, time.Time is a struct; it doesn't have zero value but IsZero can return true because it has fields with zero value. How can we merge a non-zero time.Time?
+
+	package main
+
+	import (
+		"fmt"
+		"github.com/imdario/mergo"
+			"reflect"
+			"time"
+	)
+
+	type timeTransformer struct {
+	}
+
+	func (t timeTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
+		if typ == reflect.TypeOf(time.Time{}) {
+			return func(dst, src reflect.Value) error {
+				if dst.CanSet() {
+					isZero := dst.MethodByName("IsZero")
+					result := isZero.Call([]reflect.Value{})
+					if result[0].Bool() {
+						dst.Set(src)
+					}
+				}
+				return nil
+			}
+		}
+		return nil
+	}
+
+	type Snapshot struct {
+		Time time.Time
+		// ...
+	}
+
+	func main() {
+		src := Snapshot{time.Now()}
+		dest := Snapshot{}
+		mergo.Merge(&dest, src, mergo.WithTransformers(timeTransformer{}))
+		fmt.Println(dest)
+		// Will print
+		// { 2018-01-12 01:15:00 +0000 UTC m=+0.000000001 }
+	}
+
+Contact me
+
+If I can help you, you have an idea or you are using Mergo in your projects, don't hesitate to drop me a line (or a pull request): https://twitter.com/im_dario
+
+About
+
+Written by Dario Castañé: https://da.rio.hn
+
+License
+
+BSD 3-Clause license, as Go language.
 
 */
 package mergo

--- a/vendor/github.com/imdario/mergo/merge.go
+++ b/vendor/github.com/imdario/mergo/merge.go
@@ -13,23 +13,40 @@ import (
 	"reflect"
 )
 
-func hasExportedField(dst reflect.Value) (exported bool) {
+func hasMergeableFields(dst reflect.Value) (exported bool) {
 	for i, n := 0, dst.NumField(); i < n; i++ {
 		field := dst.Type().Field(i)
 		if field.Anonymous && dst.Field(i).Kind() == reflect.Struct {
-			exported = exported || hasExportedField(dst.Field(i))
-		} else {
+			exported = exported || hasMergeableFields(dst.Field(i))
+		} else if isExportedComponent(&field) {
 			exported = exported || len(field.PkgPath) == 0
 		}
 	}
 	return
 }
 
+func isExportedComponent(field *reflect.StructField) bool {
+	pkgPath := field.PkgPath
+	if len(pkgPath) > 0 {
+		return false
+	}
+	c := field.Name[0]
+	if 'a' <= c && c <= 'z' || c == '_' {
+		return false
+	}
+	return true
+}
+
 type Config struct {
-	Overwrite               bool
-	AppendSlice             bool
-	Transformers            Transformers
-	overwriteWithEmptyValue bool
+	Transformers                 Transformers
+	Overwrite                    bool
+	ShouldNotDereference         bool
+	AppendSlice                  bool
+	TypeCheck                    bool
+	overwriteWithEmptyValue      bool
+	overwriteSliceWithEmptyValue bool
+	sliceDeepCopy                bool
+	debug                        bool
 }
 
 type Transformers interface {
@@ -41,8 +58,10 @@ type Transformers interface {
 // short circuiting on recursive types.
 func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, config *Config) (err error) {
 	overwrite := config.Overwrite
+	typeCheck := config.TypeCheck
 	overwriteWithEmptySrc := config.overwriteWithEmptyValue
-	config.overwriteWithEmptyValue = false
+	overwriteSliceWithEmptySrc := config.overwriteSliceWithEmptyValue
+	sliceDeepCopy := config.sliceDeepCopy
 
 	if !src.IsValid() {
 		return
@@ -58,10 +77,10 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 			}
 		}
 		// Remember, remember...
-		visited[h] = &visit{addr, typ, seen}
+		visited[h] = &visit{typ, seen, addr}
 	}
 
-	if config.Transformers != nil && !isEmptyValue(dst) {
+	if config.Transformers != nil && !isReflectNil(dst) && dst.IsValid() {
 		if fn := config.Transformers.Transformer(dst.Type()); fn != nil {
 			err = fn(dst, src)
 			return
@@ -70,21 +89,34 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 
 	switch dst.Kind() {
 	case reflect.Struct:
-		if hasExportedField(dst) {
+		if hasMergeableFields(dst) {
 			for i, n := 0, dst.NumField(); i < n; i++ {
 				if err = deepMerge(dst.Field(i), src.Field(i), visited, depth+1, config); err != nil {
 					return
 				}
 			}
 		} else {
-			if dst.CanSet() && (!isEmptyValue(src) || overwriteWithEmptySrc) && (overwrite || isEmptyValue(dst)) {
+			if dst.CanSet() && (isReflectNil(dst) || overwrite) && (!isEmptyValue(src, !config.ShouldNotDereference) || overwriteWithEmptySrc) {
 				dst.Set(src)
 			}
 		}
 	case reflect.Map:
 		if dst.IsNil() && !src.IsNil() {
-			dst.Set(reflect.MakeMap(dst.Type()))
+			if dst.CanSet() {
+				dst.Set(reflect.MakeMap(dst.Type()))
+			} else {
+				dst = src
+				return
+			}
 		}
+
+		if src.Kind() != reflect.Map {
+			if overwrite && dst.CanSet() {
+				dst.Set(src)
+			}
+			return
+		}
+
 		for _, key := range src.MapKeys() {
 			srcElement := src.MapIndex(key)
 			if !srcElement.IsValid() {
@@ -94,6 +126,9 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 			switch srcElement.Kind() {
 			case reflect.Chan, reflect.Func, reflect.Map, reflect.Interface, reflect.Slice:
 				if srcElement.IsNil() {
+					if overwrite {
+						dst.SetMapIndex(key, srcElement)
+					}
 					continue
 				}
 				fallthrough
@@ -128,54 +163,116 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 						dstSlice = reflect.ValueOf(dstElement.Interface())
 					}
 
-					if (!isEmptyValue(src) || overwriteWithEmptySrc) && (overwrite || isEmptyValue(dst)) && !config.AppendSlice {
+					if (!isEmptyValue(src, !config.ShouldNotDereference) || overwriteWithEmptySrc || overwriteSliceWithEmptySrc) && (overwrite || isEmptyValue(dst, !config.ShouldNotDereference)) && !config.AppendSlice && !sliceDeepCopy {
+						if typeCheck && srcSlice.Type() != dstSlice.Type() {
+							return fmt.Errorf("cannot override two slices with different type (%s, %s)", srcSlice.Type(), dstSlice.Type())
+						}
 						dstSlice = srcSlice
 					} else if config.AppendSlice {
 						if srcSlice.Type() != dstSlice.Type() {
-							return fmt.Errorf("cannot append two slice with different type (%s, %s)", srcSlice.Type(), dstSlice.Type())
+							return fmt.Errorf("cannot append two slices with different type (%s, %s)", srcSlice.Type(), dstSlice.Type())
 						}
 						dstSlice = reflect.AppendSlice(dstSlice, srcSlice)
+					} else if sliceDeepCopy {
+						i := 0
+						for ; i < srcSlice.Len() && i < dstSlice.Len(); i++ {
+							srcElement := srcSlice.Index(i)
+							dstElement := dstSlice.Index(i)
+
+							if srcElement.CanInterface() {
+								srcElement = reflect.ValueOf(srcElement.Interface())
+							}
+							if dstElement.CanInterface() {
+								dstElement = reflect.ValueOf(dstElement.Interface())
+							}
+
+							if err = deepMerge(dstElement, srcElement, visited, depth+1, config); err != nil {
+								return
+							}
+						}
+
 					}
 					dst.SetMapIndex(key, dstSlice)
 				}
 			}
-			if dstElement.IsValid() && !isEmptyValue(dstElement) && (reflect.TypeOf(srcElement.Interface()).Kind() == reflect.Map || reflect.TypeOf(srcElement.Interface()).Kind() == reflect.Slice) {
-				continue
+
+			if dstElement.IsValid() && !isEmptyValue(dstElement, !config.ShouldNotDereference) {
+				if reflect.TypeOf(srcElement.Interface()).Kind() == reflect.Slice {
+					continue
+				}
+				if reflect.TypeOf(srcElement.Interface()).Kind() == reflect.Map && reflect.TypeOf(dstElement.Interface()).Kind() == reflect.Map {
+					continue
+				}
 			}
 
-			if srcElement.IsValid() && (overwrite || (!dstElement.IsValid() || isEmptyValue(dstElement))) {
+			if srcElement.IsValid() && ((srcElement.Kind() != reflect.Ptr && overwrite) || !dstElement.IsValid() || isEmptyValue(dstElement, !config.ShouldNotDereference)) {
 				if dst.IsNil() {
 					dst.Set(reflect.MakeMap(dst.Type()))
 				}
 				dst.SetMapIndex(key, srcElement)
 			}
 		}
+
+		// Ensure that all keys in dst are deleted if they are not in src.
+		if overwriteWithEmptySrc {
+			for _, key := range dst.MapKeys() {
+				srcElement := src.MapIndex(key)
+				if !srcElement.IsValid() {
+					dst.SetMapIndex(key, reflect.Value{})
+				}
+			}
+		}
 	case reflect.Slice:
 		if !dst.CanSet() {
 			break
 		}
-		if (!isEmptyValue(src) || overwriteWithEmptySrc) && (overwrite || isEmptyValue(dst)) && !config.AppendSlice {
+		if (!isEmptyValue(src, !config.ShouldNotDereference) || overwriteWithEmptySrc || overwriteSliceWithEmptySrc) && (overwrite || isEmptyValue(dst, !config.ShouldNotDereference)) && !config.AppendSlice && !sliceDeepCopy {
 			dst.Set(src)
 		} else if config.AppendSlice {
 			if src.Type() != dst.Type() {
 				return fmt.Errorf("cannot append two slice with different type (%s, %s)", src.Type(), dst.Type())
 			}
 			dst.Set(reflect.AppendSlice(dst, src))
+		} else if sliceDeepCopy {
+			for i := 0; i < src.Len() && i < dst.Len(); i++ {
+				srcElement := src.Index(i)
+				dstElement := dst.Index(i)
+				if srcElement.CanInterface() {
+					srcElement = reflect.ValueOf(srcElement.Interface())
+				}
+				if dstElement.CanInterface() {
+					dstElement = reflect.ValueOf(dstElement.Interface())
+				}
+
+				if err = deepMerge(dstElement, srcElement, visited, depth+1, config); err != nil {
+					return
+				}
+			}
 		}
 	case reflect.Ptr:
 		fallthrough
 	case reflect.Interface:
-		if src.IsNil() {
+		if isReflectNil(src) {
+			if overwriteWithEmptySrc && dst.CanSet() && src.Type().AssignableTo(dst.Type()) {
+				dst.Set(src)
+			}
 			break
 		}
+
 		if src.Kind() != reflect.Interface {
-			if dst.IsNil() || overwrite {
-				if dst.CanSet() && (overwrite || isEmptyValue(dst)) {
+			if dst.IsNil() || (src.Kind() != reflect.Ptr && overwrite) {
+				if dst.CanSet() && (overwrite || isEmptyValue(dst, !config.ShouldNotDereference)) {
 					dst.Set(src)
 				}
 			} else if src.Kind() == reflect.Ptr {
-				if err = deepMerge(dst.Elem(), src.Elem(), visited, depth+1, config); err != nil {
-					return
+				if !config.ShouldNotDereference {
+					if err = deepMerge(dst.Elem(), src.Elem(), visited, depth+1, config); err != nil {
+						return
+					}
+				} else {
+					if overwriteWithEmptySrc || (overwrite && !src.IsNil()) || dst.IsNil() {
+						dst.Set(src)
+					}
 				}
 			} else if dst.Elem().Type() == src.Type() {
 				if err = deepMerge(dst.Elem(), src, visited, depth+1, config); err != nil {
@@ -186,18 +283,31 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 			}
 			break
 		}
+
 		if dst.IsNil() || overwrite {
-			if dst.CanSet() && (overwrite || isEmptyValue(dst)) {
+			if dst.CanSet() && (overwrite || isEmptyValue(dst, !config.ShouldNotDereference)) {
 				dst.Set(src)
 			}
-		} else if err = deepMerge(dst.Elem(), src.Elem(), visited, depth+1, config); err != nil {
-			return
+			break
+		}
+
+		if dst.Elem().Kind() == src.Elem().Kind() {
+			if err = deepMerge(dst.Elem(), src.Elem(), visited, depth+1, config); err != nil {
+				return
+			}
+			break
 		}
 	default:
-		if dst.CanSet() && (!isEmptyValue(src) || overwriteWithEmptySrc) && (overwrite || isEmptyValue(dst)) {
-			dst.Set(src)
+		mustSet := (isEmptyValue(dst, !config.ShouldNotDereference) || overwrite) && (!isEmptyValue(src, !config.ShouldNotDereference) || overwriteWithEmptySrc)
+		if mustSet {
+			if dst.CanSet() {
+				dst.Set(src)
+			} else {
+				dst = src
+			}
 		}
 	}
+
 	return
 }
 
@@ -209,7 +319,7 @@ func Merge(dst, src interface{}, opts ...func(*Config)) error {
 	return merge(dst, src, opts...)
 }
 
-// MergeWithOverwrite will do the same as Merge except that non-empty dst attributes will be overriden by
+// MergeWithOverwrite will do the same as Merge except that non-empty dst attributes will be overridden by
 // non-empty src attribute values.
 // Deprecated: use Merge(…) with WithOverride
 func MergeWithOverwrite(dst, src interface{}, opts ...func(*Config)) error {
@@ -228,12 +338,43 @@ func WithOverride(config *Config) {
 	config.Overwrite = true
 }
 
-// WithAppendSlice will make merge append slices instead of overwriting it
+// WithOverwriteWithEmptyValue will make merge override non empty dst attributes with empty src attributes values.
+func WithOverwriteWithEmptyValue(config *Config) {
+	config.Overwrite = true
+	config.overwriteWithEmptyValue = true
+}
+
+// WithOverrideEmptySlice will make merge override empty dst slice with empty src slice.
+func WithOverrideEmptySlice(config *Config) {
+	config.overwriteSliceWithEmptyValue = true
+}
+
+// WithoutDereference prevents dereferencing pointers when evaluating whether they are empty
+// (i.e. a non-nil pointer is never considered empty).
+func WithoutDereference(config *Config) {
+	config.ShouldNotDereference = true
+}
+
+// WithAppendSlice will make merge append slices instead of overwriting it.
 func WithAppendSlice(config *Config) {
 	config.AppendSlice = true
 }
 
+// WithTypeCheck will make merge check types while overwriting it (must be used with WithOverride).
+func WithTypeCheck(config *Config) {
+	config.TypeCheck = true
+}
+
+// WithSliceDeepCopy will merge slice element one by one with Overwrite flag.
+func WithSliceDeepCopy(config *Config) {
+	config.sliceDeepCopy = true
+	config.Overwrite = true
+}
+
 func merge(dst, src interface{}, opts ...func(*Config)) error {
+	if dst != nil && reflect.ValueOf(dst).Kind() != reflect.Ptr {
+		return ErrNonPointerArgument
+	}
 	var (
 		vDst, vSrc reflect.Value
 		err        error
@@ -252,4 +393,17 @@ func merge(dst, src interface{}, opts ...func(*Config)) error {
 		return ErrDifferentArgumentsTypes
 	}
 	return deepMerge(vDst, vSrc, make(map[uintptr]*visit), 0, config)
+}
+
+// IsReflectNil is the reflect value provided nil
+func isReflectNil(v reflect.Value) bool {
+	k := v.Kind()
+	switch k {
+	case reflect.Interface, reflect.Slice, reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr:
+		// Both interface and slice are nil if first word is 0.
+		// Both are always bigger than a word; assume flagIndir.
+		return v.IsNil()
+	default:
+		return false
+	}
 }

--- a/vendor/github.com/imdario/mergo/mergo.go
+++ b/vendor/github.com/imdario/mergo/mergo.go
@@ -17,9 +17,10 @@ import (
 var (
 	ErrNilArguments                = errors.New("src and dst must not be nil")
 	ErrDifferentArgumentsTypes     = errors.New("src and dst must be of same type")
-	ErrNotSupported                = errors.New("only structs and maps are supported")
+	ErrNotSupported                = errors.New("only structs, maps, and slices are supported")
 	ErrExpectedMapAsDestination    = errors.New("dst was expected to be a map")
 	ErrExpectedStructAsDestination = errors.New("dst was expected to be a struct")
+	ErrNonPointerArgument          = errors.New("dst must be a pointer")
 )
 
 // During deepMerge, must keep track of checks that are
@@ -27,13 +28,13 @@ var (
 // checks in progress are true when it reencounters them.
 // Visited are stored in a map indexed by 17 * a1 + a2;
 type visit struct {
-	ptr  uintptr
 	typ  reflect.Type
 	next *visit
+	ptr  uintptr
 }
 
 // From src/pkg/encoding/json/encode.go.
-func isEmptyValue(v reflect.Value) bool {
+func isEmptyValue(v reflect.Value, shouldDereference bool) bool {
 	switch v.Kind() {
 	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
 		return v.Len() == 0
@@ -49,7 +50,10 @@ func isEmptyValue(v reflect.Value) bool {
 		if v.IsNil() {
 			return true
 		}
-		return isEmptyValue(v.Elem())
+		if shouldDereference {
+			return isEmptyValue(v.Elem(), shouldDereference)
+		}
+		return false
 	case reflect.Func:
 		return v.IsNil()
 	case reflect.Invalid:
@@ -64,7 +68,7 @@ func resolveValues(dst, src interface{}) (vDst, vSrc reflect.Value, err error) {
 		return
 	}
 	vDst = reflect.ValueOf(dst).Elem()
-	if vDst.Kind() != reflect.Struct && vDst.Kind() != reflect.Map {
+	if vDst.Kind() != reflect.Struct && vDst.Kind() != reflect.Map && vDst.Kind() != reflect.Slice {
 		err = ErrNotSupported
 		return
 	}
@@ -74,24 +78,4 @@ func resolveValues(dst, src interface{}) (vDst, vSrc reflect.Value, err error) {
 		vSrc = vSrc.Elem()
 	}
 	return
-}
-
-// Traverses recursively both values, assigning src's fields values to dst.
-// The map argument tracks comparisons that have already been seen, which allows
-// short circuiting on recursive types.
-func deeper(dst, src reflect.Value, visited map[uintptr]*visit, depth int) (err error) {
-	if dst.CanAddr() {
-		addr := dst.UnsafeAddr()
-		h := 17 * addr
-		seen := visited[h]
-		typ := dst.Type()
-		for p := seen; p != nil; p = p.next {
-			if p.ptr == addr && p.typ == typ {
-				return nil
-			}
-		}
-		// Remember, remember...
-		visited[h] = &visit{addr, typ, seen}
-	}
-	return // TODO refactor
 }

--- a/vendor/github.com/openshift/api/features/features.go
+++ b/vendor/github.com/openshift/api/features/features.go
@@ -1,0 +1,591 @@
+package features
+
+import (
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func FeatureSets(clusterProfile ClusterProfileName, featureSet configv1.FeatureSet) (*FeatureGateEnabledDisabled, error) {
+	byFeatureSet, ok := allFeatureGates[clusterProfile]
+	if !ok {
+		return nil, fmt.Errorf("no information found for ClusterProfile=%q", clusterProfile)
+	}
+	featureGates, ok := byFeatureSet[featureSet]
+	if !ok {
+		return nil, fmt.Errorf("no information found for FeatureSet=%q under ClusterProfile=%q", featureSet, clusterProfile)
+	}
+	return featureGates.DeepCopy(), nil
+}
+
+func AllFeatureSets() map[ClusterProfileName]map[configv1.FeatureSet]*FeatureGateEnabledDisabled {
+	ret := map[ClusterProfileName]map[configv1.FeatureSet]*FeatureGateEnabledDisabled{}
+
+	for clusterProfile, byFeatureSet := range allFeatureGates {
+		newByFeatureSet := map[configv1.FeatureSet]*FeatureGateEnabledDisabled{}
+
+		for featureSet, enabledDisabled := range byFeatureSet {
+			newByFeatureSet[featureSet] = enabledDisabled.DeepCopy()
+		}
+		ret[clusterProfile] = newByFeatureSet
+	}
+
+	return ret
+}
+
+var (
+	allFeatureGates = map[ClusterProfileName]map[configv1.FeatureSet]*FeatureGateEnabledDisabled{}
+
+	FeatureGateServiceAccountTokenNodeBinding = newFeatureGate("ServiceAccountTokenNodeBinding").
+							reportProblemsToJiraComponent("apiserver-auth").
+							contactPerson("stlaz").
+							productScope(kubernetes).
+							enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+							mustRegister()
+
+	FeatureGateValidatingAdmissionPolicy = newFeatureGate("ValidatingAdmissionPolicy").
+						reportProblemsToJiraComponent("kube-apiserver").
+						contactPerson("benluddy").
+						productScope(kubernetes).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateGatewayAPI = newFeatureGate("GatewayAPI").
+				reportProblemsToJiraComponent("Routing").
+				contactPerson("miciah").
+				productScope(ocpSpecific).
+				enableIn(configv1.DevPreviewNoUpgrade).
+				mustRegister()
+
+	FeatureGateSetEIPForNLBIngressController = newFeatureGate("SetEIPForNLBIngressController").
+							reportProblemsToJiraComponent("Networking / router").
+							contactPerson("miheer").
+							productScope(ocpSpecific).
+							enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+							mustRegister()
+
+	FeatureGateOpenShiftPodSecurityAdmission = newFeatureGate("OpenShiftPodSecurityAdmission").
+							reportProblemsToJiraComponent("auth").
+							contactPerson("stlaz").
+							productScope(ocpSpecific).
+							enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+							mustRegister()
+
+	FeatureGateExternalCloudProvider = newFeatureGate("ExternalCloudProvider").
+						reportProblemsToJiraComponent("cloud-provider").
+						contactPerson("jspeed").
+						productScope(ocpSpecific).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateExternalCloudProviderAzure = newFeatureGate("ExternalCloudProviderAzure").
+						reportProblemsToJiraComponent("cloud-provider").
+						contactPerson("jspeed").
+						productScope(ocpSpecific).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateExternalCloudProviderGCP = newFeatureGate("ExternalCloudProviderGCP").
+						reportProblemsToJiraComponent("cloud-provider").
+						contactPerson("jspeed").
+						productScope(ocpSpecific).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateExternalCloudProviderExternal = newFeatureGate("ExternalCloudProviderExternal").
+							reportProblemsToJiraComponent("cloud-provider").
+							contactPerson("elmiko").
+							productScope(ocpSpecific).
+							enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+							mustRegister()
+
+	FeatureGateCSIDriverSharedResource = newFeatureGate("CSIDriverSharedResource").
+						reportProblemsToJiraComponent("builds").
+						contactPerson("adkaplan").
+						productScope(ocpSpecific).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateBuildCSIVolumes = newFeatureGate("BuildCSIVolumes").
+					reportProblemsToJiraComponent("builds").
+					contactPerson("adkaplan").
+					productScope(ocpSpecific).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateNodeSwap = newFeatureGate("NodeSwap").
+				reportProblemsToJiraComponent("node").
+				contactPerson("ehashman").
+				productScope(kubernetes).
+				enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+				mustRegister()
+
+	FeatureGateMachineAPIProviderOpenStack = newFeatureGate("MachineAPIProviderOpenStack").
+						reportProblemsToJiraComponent("openstack").
+						contactPerson("egarcia").
+						productScope(ocpSpecific).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateInsightsConfigAPI = newFeatureGate("InsightsConfigAPI").
+					reportProblemsToJiraComponent("insights").
+					contactPerson("tremes").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateDynamicResourceAllocation = newFeatureGate("DynamicResourceAllocation").
+						reportProblemsToJiraComponent("scheduling").
+						contactPerson("jchaloup").
+						productScope(kubernetes).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateAzureWorkloadIdentity = newFeatureGate("AzureWorkloadIdentity").
+						reportProblemsToJiraComponent("cloud-credential-operator").
+						contactPerson("abutcher").
+						productScope(ocpSpecific).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateMaxUnavailableStatefulSet = newFeatureGate("MaxUnavailableStatefulSet").
+						reportProblemsToJiraComponent("apps").
+						contactPerson("atiratree").
+						productScope(kubernetes).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateEventedPLEG = newFeatureGate("EventedPLEG").
+				reportProblemsToJiraComponent("node").
+				contactPerson("sairameshv").
+				productScope(kubernetes).
+				mustRegister()
+
+	FeatureGatePrivateHostedZoneAWS = newFeatureGate("PrivateHostedZoneAWS").
+					reportProblemsToJiraComponent("Routing").
+					contactPerson("miciah").
+					productScope(ocpSpecific).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateSigstoreImageVerification = newFeatureGate("SigstoreImageVerification").
+						reportProblemsToJiraComponent("node").
+						contactPerson("sgrunert").
+						productScope(ocpSpecific).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateGCPLabelsTags = newFeatureGate("GCPLabelsTags").
+					reportProblemsToJiraComponent("Installer").
+					contactPerson("bhb").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateAlibabaPlatform = newFeatureGate("AlibabaPlatform").
+					reportProblemsToJiraComponent("cloud-provider").
+					contactPerson("jspeed").
+					productScope(ocpSpecific).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateCloudDualStackNodeIPs = newFeatureGate("CloudDualStackNodeIPs").
+						reportProblemsToJiraComponent("machine-config-operator/platform-baremetal").
+						contactPerson("mkowalsk").
+						productScope(kubernetes).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateVSphereMultiVCenters = newFeatureGate("VSphereMultiVCenters").
+					reportProblemsToJiraComponent("splat").
+					contactPerson("vr4manta").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateVSphereStaticIPs = newFeatureGate("VSphereStaticIPs").
+					reportProblemsToJiraComponent("splat").
+					contactPerson("rvanderp3").
+					productScope(ocpSpecific).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateRouteExternalCertificate = newFeatureGate("RouteExternalCertificate").
+						reportProblemsToJiraComponent("router").
+						contactPerson("thejasn").
+						productScope(ocpSpecific).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateAdminNetworkPolicy = newFeatureGate("AdminNetworkPolicy").
+					reportProblemsToJiraComponent("Networking/ovn-kubernetes").
+					contactPerson("tssurya").
+					productScope(ocpSpecific).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateNetworkSegmentation = newFeatureGate("NetworkSegmentation").
+					reportProblemsToJiraComponent("Networking/ovn-kubernetes").
+					contactPerson("tssurya").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateNetworkLiveMigration = newFeatureGate("NetworkLiveMigration").
+					reportProblemsToJiraComponent("Networking/ovn-kubernetes").
+					contactPerson("pliu").
+					productScope(ocpSpecific).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateNetworkDiagnosticsConfig = newFeatureGate("NetworkDiagnosticsConfig").
+						reportProblemsToJiraComponent("Networking/cluster-network-operator").
+						contactPerson("kyrtapz").
+						productScope(ocpSpecific).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateHardwareSpeed = newFeatureGate("HardwareSpeed").
+					reportProblemsToJiraComponent("etcd").
+					contactPerson("hasbro17").
+					productScope(ocpSpecific).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateBackendQuotaGiB = newFeatureGate("EtcdBackendQuota").
+					reportProblemsToJiraComponent("etcd").
+					contactPerson("hasbro17").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateAutomatedEtcdBackup = newFeatureGate("AutomatedEtcdBackup").
+					reportProblemsToJiraComponent("etcd").
+					contactPerson("hasbro17").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateMachineAPIOperatorDisableMachineHealthCheckController = newFeatureGate("MachineAPIOperatorDisableMachineHealthCheckController").
+										reportProblemsToJiraComponent("ecoproject").
+										contactPerson("msluiter").
+										productScope(ocpSpecific).
+										mustRegister()
+
+	FeatureGateDNSNameResolver = newFeatureGate("DNSNameResolver").
+					reportProblemsToJiraComponent("dns").
+					contactPerson("miciah").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateVSphereControlPlaneMachineset = newFeatureGate("VSphereControlPlaneMachineSet").
+							reportProblemsToJiraComponent("splat").
+							contactPerson("rvanderp3").
+							productScope(ocpSpecific).
+							enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+							mustRegister()
+
+	FeatureGateMachineConfigNodes = newFeatureGate("MachineConfigNodes").
+					reportProblemsToJiraComponent("MachineConfigOperator").
+					contactPerson("cdoern").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateClusterAPIInstall = newFeatureGate("ClusterAPIInstall").
+					reportProblemsToJiraComponent("Installer").
+					contactPerson("vincepri").
+					productScope(ocpSpecific).
+					mustRegister()
+
+	FeatureGateMetricsServer = newFeatureGate("MetricsServer").
+					reportProblemsToJiraComponent("Monitoring").
+					contactPerson("slashpai").
+					productScope(ocpSpecific).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateInstallAlternateInfrastructureAWS = newFeatureGate("InstallAlternateInfrastructureAWS").
+							reportProblemsToJiraComponent("Installer").
+							contactPerson("padillon").
+							productScope(ocpSpecific).
+							enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+							mustRegister()
+
+	FeatureGateGCPClusterHostedDNS = newFeatureGate("GCPClusterHostedDNS").
+					reportProblemsToJiraComponent("Installer").
+					contactPerson("barbacbd").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateMixedCPUsAllocation = newFeatureGate("MixedCPUsAllocation").
+					reportProblemsToJiraComponent("NodeTuningOperator").
+					contactPerson("titzhak").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateManagedBootImages = newFeatureGate("ManagedBootImages").
+					reportProblemsToJiraComponent("MachineConfigOperator").
+					contactPerson("djoshy").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateManagedBootImagesAWS = newFeatureGate("ManagedBootImagesAWS").
+					reportProblemsToJiraComponent("MachineConfigOperator").
+					contactPerson("djoshy").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateDisableKubeletCloudCredentialProviders = newFeatureGate("DisableKubeletCloudCredentialProviders").
+								reportProblemsToJiraComponent("cloud-provider").
+								contactPerson("jspeed").
+								productScope(kubernetes).
+								enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+								mustRegister()
+
+	FeatureGateOnClusterBuild = newFeatureGate("OnClusterBuild").
+					reportProblemsToJiraComponent("MachineConfigOperator").
+					contactPerson("dkhater").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateBootcNodeManagement = newFeatureGate("BootcNodeManagement").
+					reportProblemsToJiraComponent("MachineConfigOperator").
+					contactPerson("inesqyx").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateSignatureStores = newFeatureGate("SignatureStores").
+					reportProblemsToJiraComponent("Cluster Version Operator").
+					contactPerson("lmohanty").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateKMSv1 = newFeatureGate("KMSv1").
+				reportProblemsToJiraComponent("kube-apiserver").
+				contactPerson("dgrisonnet").
+				productScope(kubernetes).
+				enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+				mustRegister()
+
+	FeatureGatePinnedImages = newFeatureGate("PinnedImages").
+				reportProblemsToJiraComponent("MachineConfigOperator").
+				contactPerson("jhernand").
+				productScope(ocpSpecific).
+				enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+				mustRegister()
+
+	FeatureGateUpgradeStatus = newFeatureGate("UpgradeStatus").
+					reportProblemsToJiraComponent("Cluster Version Operator").
+					contactPerson("pmuller").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateTranslateStreamCloseWebsocketRequests = newFeatureGate("TranslateStreamCloseWebsocketRequests").
+								reportProblemsToJiraComponent("kube-apiserver").
+								contactPerson("akashem").
+								productScope(kubernetes).
+								enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+								mustRegister()
+
+	FeatureGateVolumeGroupSnapshot = newFeatureGate("VolumeGroupSnapshot").
+					reportProblemsToJiraComponent("Storage / Kubernetes External Components").
+					contactPerson("fbertina").
+					productScope(kubernetes).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateExternalOIDC = newFeatureGate("ExternalOIDC").
+				reportProblemsToJiraComponent("authentication").
+				contactPerson("stlaz").
+				productScope(ocpSpecific).
+				enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+				enableForClusterProfile(Hypershift, configv1.Default, configv1.TechPreviewNoUpgrade).
+				mustRegister()
+
+	FeatureGateExample = newFeatureGate("Example").
+				reportProblemsToJiraComponent("cluster-config").
+				contactPerson("deads").
+				productScope(ocpSpecific).
+				enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+				mustRegister()
+
+	FeatureGatePlatformOperators = newFeatureGate("PlatformOperators").
+					reportProblemsToJiraComponent("olm").
+					contactPerson("joe").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateNewOLM = newFeatureGate("NewOLM").
+				reportProblemsToJiraComponent("olm").
+				contactPerson("joe").
+				productScope(ocpSpecific).
+				enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+				mustRegister()
+
+	FeatureGateExternalRouteCertificate = newFeatureGate("ExternalRouteCertificate").
+						reportProblemsToJiraComponent("network-edge").
+						contactPerson("miciah").
+						productScope(ocpSpecific).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateInsightsOnDemandDataGather = newFeatureGate("InsightsOnDemandDataGather").
+						reportProblemsToJiraComponent("insights").
+						contactPerson("tremes").
+						productScope(ocpSpecific).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateBareMetalLoadBalancer = newFeatureGate("BareMetalLoadBalancer").
+						reportProblemsToJiraComponent("metal").
+						contactPerson("EmilienM").
+						productScope(ocpSpecific).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateInsightsConfig = newFeatureGate("InsightsConfig").
+					reportProblemsToJiraComponent("insights").
+					contactPerson("tremes").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateNodeDisruptionPolicy = newFeatureGate("NodeDisruptionPolicy").
+					reportProblemsToJiraComponent("MachineConfigOperator").
+					contactPerson("jerzhang").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateMetricsCollectionProfiles = newFeatureGate("MetricsCollectionProfiles").
+						reportProblemsToJiraComponent("Monitoring").
+						contactPerson("rexagod").
+						productScope(ocpSpecific).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateVSphereDriverConfiguration = newFeatureGate("VSphereDriverConfiguration").
+						reportProblemsToJiraComponent("Storage / Kubernetes External Components").
+						contactPerson("rbednar").
+						productScope(ocpSpecific).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateClusterAPIInstallAWS = newFeatureGate("ClusterAPIInstallAWS").
+					reportProblemsToJiraComponent("Installer").
+					contactPerson("r4f4").
+					productScope(ocpSpecific).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateClusterAPIInstallAzure = newFeatureGate("ClusterAPIInstallAzure").
+						reportProblemsToJiraComponent("Installer").
+						contactPerson("jhixson74").
+						productScope(ocpSpecific).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateClusterAPIInstallGCP = newFeatureGate("ClusterAPIInstallGCP").
+					reportProblemsToJiraComponent("Installer").
+					contactPerson("bfournie").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateClusterAPIInstallIBMCloud = newFeatureGate("ClusterAPIInstallIBMCloud").
+						reportProblemsToJiraComponent("Installer").
+						contactPerson("cjschaef").
+						productScope(ocpSpecific).
+						mustRegister()
+
+	FeatureGateClusterAPIInstallNutanix = newFeatureGate("ClusterAPIInstallNutanix").
+						reportProblemsToJiraComponent("Installer").
+						contactPerson("yanhua121").
+						productScope(ocpSpecific).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateClusterAPIInstallOpenStack = newFeatureGate("ClusterAPIInstallOpenStack").
+						reportProblemsToJiraComponent("Installer").
+						contactPerson("stephenfin").
+						productScope(ocpSpecific).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateClusterAPIInstallPowerVS = newFeatureGate("ClusterAPIInstallPowerVS").
+						reportProblemsToJiraComponent("Installer").
+						contactPerson("mjturek").
+						productScope(ocpSpecific).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateClusterAPIInstallVSphere = newFeatureGate("ClusterAPIInstallVSphere").
+						reportProblemsToJiraComponent("Installer").
+						contactPerson("rvanderp3").
+						productScope(ocpSpecific).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateChunkSizeMiB = newFeatureGate("ChunkSizeMiB").
+				reportProblemsToJiraComponent("Image Registry").
+				contactPerson("flavianmissi").
+				productScope(ocpSpecific).
+				enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+				mustRegister()
+
+	FeatureGateMachineAPIMigration = newFeatureGate("MachineAPIMigration").
+					reportProblemsToJiraComponent("OCPCLOUD").
+					contactPerson("jspeed").
+					productScope(ocpSpecific).
+					mustRegister()
+
+	FeatureGatePersistentIPsForVirtualization = newFeatureGate("PersistentIPsForVirtualization").
+							reportProblemsToJiraComponent("CNV Network").
+							contactPerson("mduarted").
+							productScope(ocpSpecific).
+							enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+							mustRegister()
+
+	FeatureGateClusterMonitoringConfig = newFeatureGate("ClusterMonitoringConfig").
+						reportProblemsToJiraComponent("Monitoring").
+						contactPerson("marioferh").
+						productScope(ocpSpecific).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateMultiArchInstallAWS = newFeatureGate("MultiArchInstallAWS").
+					reportProblemsToJiraComponent("Installer").
+					contactPerson("r4f4").
+					productScope(ocpSpecific).
+					mustRegister()
+
+	FeatureGateMultiArchInstallAzure = newFeatureGate("MultiArchInstallAzure").
+						reportProblemsToJiraComponent("Installer").
+						contactPerson("r4f4").
+						productScope(ocpSpecific).
+						mustRegister()
+
+	FeatureGateMultiArchInstallGCP = newFeatureGate("MultiArchInstallGCP").
+					reportProblemsToJiraComponent("Installer").
+					contactPerson("r4f4").
+					productScope(ocpSpecific).
+					mustRegister()
+
+	FeatureGateIngressControllerLBSubnetsAWS = newFeatureGate("IngressControllerLBSubnetsAWS").
+							reportProblemsToJiraComponent("Routing").
+							contactPerson("miciah").
+							productScope(ocpSpecific).
+							enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+							mustRegister()
+)

--- a/vendor/github.com/openshift/api/features/util.go
+++ b/vendor/github.com/openshift/api/features/util.go
@@ -1,0 +1,193 @@
+package features
+
+import (
+	"fmt"
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// FeatureGateDescription is a golang-only interface used to contains details for a feature gate.
+type FeatureGateDescription struct {
+	// FeatureGateAttributes is the information that appears in the API
+	FeatureGateAttributes configv1.FeatureGateAttributes
+
+	// OwningJiraComponent is the jira component that owns most of the impl and first assignment for the bug.
+	// This is the team that owns the feature long term.
+	OwningJiraComponent string
+	// ResponsiblePerson is the person who is on the hook for first contact.  This is often, but not always, a team lead.
+	// It is someone who can make the promise on the behalf of the team.
+	ResponsiblePerson string
+	// OwningProduct is the product that owns the lifecycle of the gate.
+	OwningProduct OwningProduct
+}
+
+type FeatureGateEnabledDisabled struct {
+	Enabled  []FeatureGateDescription
+	Disabled []FeatureGateDescription
+}
+
+type ClusterProfileName string
+
+var (
+	Hypershift         = ClusterProfileName("include.release.openshift.io/ibm-cloud-managed")
+	SelfManaged        = ClusterProfileName("include.release.openshift.io/self-managed-high-availability")
+	AllClusterProfiles = []ClusterProfileName{Hypershift, SelfManaged}
+)
+
+type OwningProduct string
+
+var (
+	ocpSpecific = OwningProduct("OCP")
+	kubernetes  = OwningProduct("Kubernetes")
+)
+
+type featureGateBuilder struct {
+	name                string
+	owningJiraComponent string
+	responsiblePerson   string
+	owningProduct       OwningProduct
+
+	statusByClusterProfileByFeatureSet map[ClusterProfileName]map[configv1.FeatureSet]bool
+}
+
+// newFeatureGate featuregate are disabled in every FeatureSet and selectively enabled
+func newFeatureGate(name string) *featureGateBuilder {
+	b := &featureGateBuilder{
+		name:                               name,
+		statusByClusterProfileByFeatureSet: map[ClusterProfileName]map[configv1.FeatureSet]bool{},
+	}
+	for _, clusterProfile := range AllClusterProfiles {
+		byFeatureSet := map[configv1.FeatureSet]bool{}
+		for _, featureSet := range configv1.AllFixedFeatureSets {
+			byFeatureSet[featureSet] = false
+		}
+		b.statusByClusterProfileByFeatureSet[clusterProfile] = byFeatureSet
+	}
+	return b
+}
+
+func (b *featureGateBuilder) reportProblemsToJiraComponent(owningJiraComponent string) *featureGateBuilder {
+	b.owningJiraComponent = owningJiraComponent
+	return b
+}
+
+func (b *featureGateBuilder) contactPerson(responsiblePerson string) *featureGateBuilder {
+	b.responsiblePerson = responsiblePerson
+	return b
+}
+
+func (b *featureGateBuilder) productScope(owningProduct OwningProduct) *featureGateBuilder {
+	b.owningProduct = owningProduct
+	return b
+}
+
+func (b *featureGateBuilder) enableIn(featureSets ...configv1.FeatureSet) *featureGateBuilder {
+	for clusterProfile := range b.statusByClusterProfileByFeatureSet {
+		for _, featureSet := range featureSets {
+			b.statusByClusterProfileByFeatureSet[clusterProfile][featureSet] = true
+		}
+	}
+	return b
+}
+
+func (b *featureGateBuilder) enableForClusterProfile(clusterProfile ClusterProfileName, featureSets ...configv1.FeatureSet) *featureGateBuilder {
+	for _, featureSet := range featureSets {
+		b.statusByClusterProfileByFeatureSet[clusterProfile][featureSet] = true
+	}
+	return b
+}
+
+func (b *featureGateBuilder) register() (configv1.FeatureGateName, error) {
+	if len(b.name) == 0 {
+		return "", fmt.Errorf("missing name")
+	}
+	if len(b.owningJiraComponent) == 0 {
+		return "", fmt.Errorf("missing owningJiraComponent")
+	}
+	if len(b.responsiblePerson) == 0 {
+		return "", fmt.Errorf("missing responsiblePerson")
+	}
+	if len(b.owningProduct) == 0 {
+		return "", fmt.Errorf("missing owningProduct")
+	}
+
+	featureGateName := configv1.FeatureGateName(b.name)
+	description := FeatureGateDescription{
+		FeatureGateAttributes: configv1.FeatureGateAttributes{
+			Name: featureGateName,
+		},
+		OwningJiraComponent: b.owningJiraComponent,
+		ResponsiblePerson:   b.responsiblePerson,
+		OwningProduct:       b.owningProduct,
+	}
+
+	// statusByClusterProfileByFeatureSet is initialized by constructor to be false for every combination
+	for clusterProfile, byFeatureSet := range b.statusByClusterProfileByFeatureSet {
+		for featureSet, enabled := range byFeatureSet {
+			if _, ok := allFeatureGates[clusterProfile]; !ok {
+				allFeatureGates[clusterProfile] = map[configv1.FeatureSet]*FeatureGateEnabledDisabled{}
+			}
+			if _, ok := allFeatureGates[clusterProfile][featureSet]; !ok {
+				allFeatureGates[clusterProfile][featureSet] = &FeatureGateEnabledDisabled{}
+			}
+
+			if enabled {
+				allFeatureGates[clusterProfile][featureSet].Enabled = append(allFeatureGates[clusterProfile][featureSet].Enabled, description)
+			} else {
+				allFeatureGates[clusterProfile][featureSet].Disabled = append(allFeatureGates[clusterProfile][featureSet].Disabled, description)
+			}
+		}
+	}
+
+	return featureGateName, nil
+}
+
+func (b *featureGateBuilder) mustRegister() configv1.FeatureGateName {
+	ret, err := b.register()
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}
+
+// DeepCopyInto is an autogenerated deepcopy function, copying the receiver, writing into out. in must be non-nil.
+func (in *FeatureGateEnabledDisabled) DeepCopyInto(out *FeatureGateEnabledDisabled) {
+	*out = *in
+	if in.Enabled != nil {
+		in, out := &in.Enabled, &out.Enabled
+		*out = make([]FeatureGateDescription, len(*in))
+		copy(*out, *in)
+	}
+	if in.Disabled != nil {
+		in, out := &in.Disabled, &out.Disabled
+		*out = make([]FeatureGateDescription, len(*in))
+		copy(*out, *in)
+	}
+	return
+}
+
+// DeepCopy is an autogenerated deepcopy function, copying the receiver, creating a new FeatureGateEnabledDisabled.
+func (in *FeatureGateEnabledDisabled) DeepCopy() *FeatureGateEnabledDisabled {
+	if in == nil {
+		return nil
+	}
+	out := new(FeatureGateEnabledDisabled)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// DeepCopyInto is an autogenerated deepcopy function, copying the receiver, writing into out. in must be non-nil.
+func (in *FeatureGateDescription) DeepCopyInto(out *FeatureGateDescription) {
+	*out = *in
+	out.FeatureGateAttributes = in.FeatureGateAttributes
+	return
+}
+
+// DeepCopy is an autogenerated deepcopy function, copying the receiver, creating a new FeatureGateDescription.
+func (in *FeatureGateDescription) DeepCopy() *FeatureGateDescription {
+	if in == nil {
+		return nil
+	}
+	out := new(FeatureGateDescription)
+	in.DeepCopyInto(out)
+	return out
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/featuregate.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/featuregate.go
@@ -1,0 +1,48 @@
+package featuregates
+
+import (
+	"fmt"
+	"slices"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// FeatureGate indicates whether a given feature is enabled or not
+// This interface is heavily influenced by k8s.io/component-base, but not exactly compatible.
+type FeatureGate interface {
+	// Enabled returns true if the key is enabled.
+	Enabled(key configv1.FeatureGateName) bool
+	// KnownFeatures returns a slice of strings describing the FeatureGate's known features.
+	KnownFeatures() []configv1.FeatureGateName
+}
+
+type featureGate struct {
+	enabled  []configv1.FeatureGateName
+	disabled []configv1.FeatureGateName
+}
+
+func NewFeatureGate(enabled, disabled []configv1.FeatureGateName) FeatureGate {
+	return &featureGate{
+		enabled:  enabled,
+		disabled: disabled,
+	}
+}
+
+func (f *featureGate) Enabled(key configv1.FeatureGateName) bool {
+	if slices.Contains(f.enabled, key) {
+		return true
+	}
+	if slices.Contains(f.disabled, key) {
+		return false
+	}
+
+	panic(fmt.Errorf("feature %q is not registered in FeatureGates %v", key, f.KnownFeatures()))
+}
+
+func (f *featureGate) KnownFeatures() []configv1.FeatureGateName {
+	allKnown := make([]configv1.FeatureGateName, 0, len(f.enabled)+len(f.disabled))
+	allKnown = append(allKnown, f.enabled...)
+	allKnown = append(allKnown, f.disabled...)
+
+	return allKnown
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/hardcoded_featuregate_reader.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/hardcoded_featuregate_reader.go
@@ -1,0 +1,78 @@
+package featuregates
+
+import (
+	"context"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+type hardcodedFeatureGateAccess struct {
+	enabled  []configv1.FeatureGateName
+	disabled []configv1.FeatureGateName
+	readErr  error
+
+	initialFeatureGatesObserved chan struct{}
+}
+
+// NewHardcodedFeatureGateAccess returns a FeatureGateAccess that is always initialized and always
+// returns the provided feature gates.
+func NewHardcodedFeatureGateAccess(enabled, disabled []configv1.FeatureGateName) FeatureGateAccess {
+	initialFeatureGatesObserved := make(chan struct{})
+	close(initialFeatureGatesObserved)
+	c := &hardcodedFeatureGateAccess{
+		enabled:                     enabled,
+		disabled:                    disabled,
+		initialFeatureGatesObserved: initialFeatureGatesObserved,
+	}
+
+	return c
+}
+
+// NewHardcodedFeatureGateAccessForTesting returns a FeatureGateAccess that returns stub responses
+// using caller-supplied values.
+func NewHardcodedFeatureGateAccessForTesting(enabled, disabled []configv1.FeatureGateName, initialFeatureGatesObserved chan struct{}, readErr error) FeatureGateAccess {
+	return &hardcodedFeatureGateAccess{
+		enabled:                     enabled,
+		disabled:                    disabled,
+		initialFeatureGatesObserved: initialFeatureGatesObserved,
+		readErr:                     readErr,
+	}
+}
+
+func (c *hardcodedFeatureGateAccess) SetChangeHandler(featureGateChangeHandlerFn FeatureGateChangeHandlerFunc) {
+	// ignore
+}
+
+func (c *hardcodedFeatureGateAccess) Run(ctx context.Context) {
+	// ignore
+}
+
+func (c *hardcodedFeatureGateAccess) InitialFeatureGatesObserved() <-chan struct{} {
+	return c.initialFeatureGatesObserved
+}
+
+func (c *hardcodedFeatureGateAccess) AreInitialFeatureGatesObserved() bool {
+	select {
+	case <-c.InitialFeatureGatesObserved():
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *hardcodedFeatureGateAccess) CurrentFeatureGates() (FeatureGate, error) {
+	return NewFeatureGate(c.enabled, c.disabled), c.readErr
+}
+
+// NewHardcodedFeatureGateAccessFromFeatureGate returns a FeatureGateAccess that is static and initialised from
+// a populated FeatureGate status.
+// If the desired version is missing, this will return an error.
+func NewHardcodedFeatureGateAccessFromFeatureGate(featureGate *configv1.FeatureGate, desiredVersion string) (FeatureGateAccess, error) {
+	features, err := featuresFromFeatureGate(featureGate, desiredVersion)
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine features: %w", err)
+	}
+
+	return NewHardcodedFeatureGateAccess(features.Enabled, features.Disabled), nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/observe_featuregates.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/observe_featuregates.go
@@ -1,0 +1,118 @@
+package featuregates
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+// NewObserveFeatureFlagsFunc produces a configobserver for feature gates.  If non-nil, the featureWhitelist filters
+// feature gates to a known subset (instead of everything).  The featureBlacklist will stop certain features from making
+// it through the list.  The featureBlacklist should be empty, but for a brief time, some featuregates may need to skipped.
+// @smarterclayton will live forever in shame for being the first to require this for "IPv6DualStack".
+func NewObserveFeatureFlagsFunc(featureWhitelist sets.Set[configv1.FeatureGateName], featureBlacklist sets.Set[configv1.FeatureGateName], configPath []string, featureGateAccess FeatureGateAccess) configobserver.ObserveConfigFunc {
+	return (&featureFlags{
+		allowAll:          len(featureWhitelist) == 0,
+		featureWhitelist:  featureWhitelist,
+		featureBlacklist:  featureBlacklist,
+		configPath:        configPath,
+		featureGateAccess: featureGateAccess,
+	}).ObserveFeatureFlags
+}
+
+type featureFlags struct {
+	allowAll         bool
+	featureWhitelist sets.Set[configv1.FeatureGateName]
+	// we add a forceDisableFeature list because we've now had bad featuregates break individual operators.  Awesome.
+	featureBlacklist  sets.Set[configv1.FeatureGateName]
+	configPath        []string
+	featureGateAccess FeatureGateAccess
+}
+
+// ObserveFeatureFlags fills in --feature-flags for the kube-apiserver
+func (f *featureFlags) ObserveFeatureFlags(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+	prunedExistingConfig := configobserver.Pruned(existingConfig, f.configPath)
+
+	errs := []error{}
+
+	if !f.featureGateAccess.AreInitialFeatureGatesObserved() {
+		// if we haven't observed featuregates yet, return the existing
+		return prunedExistingConfig, nil
+	}
+
+	featureGates, err := f.featureGateAccess.CurrentFeatureGates()
+	if err != nil {
+		return prunedExistingConfig, append(errs, err)
+	}
+	observedConfig := map[string]interface{}{}
+	newConfigValue := f.getWhitelistedFeatureNames(featureGates)
+
+	currentConfigValue, _, err := unstructured.NestedStringSlice(existingConfig, f.configPath...)
+	if err != nil {
+		errs = append(errs, err)
+		// keep going on read error from existing config
+	}
+	if !reflect.DeepEqual(currentConfigValue, newConfigValue) {
+		recorder.Eventf("ObserveFeatureFlagsUpdated", "Updated %v to %s", strings.Join(f.configPath, "."), strings.Join(newConfigValue, ","))
+	}
+
+	if err := unstructured.SetNestedStringSlice(observedConfig, newConfigValue, f.configPath...); err != nil {
+		recorder.Warningf("ObserveFeatureFlags", "Failed setting %v: %v", strings.Join(f.configPath, "."), err)
+		return prunedExistingConfig, append(errs, err)
+	}
+
+	return configobserver.Pruned(observedConfig, f.configPath), errs
+}
+
+func (f *featureFlags) getWhitelistedFeatureNames(featureGates FeatureGate) []string {
+	newConfigValue := []string{}
+	formatEnabledFunc := func(fs configv1.FeatureGateName) string {
+		return fmt.Sprintf("%v=true", fs)
+	}
+	formatDisabledFunc := func(fs configv1.FeatureGateName) string {
+		return fmt.Sprintf("%v=false", fs)
+	}
+
+	for _, knownFeatureGate := range featureGates.KnownFeatures() {
+		if f.featureBlacklist.Has(knownFeatureGate) {
+			continue
+		}
+		// only add whitelisted feature flags
+		if !f.allowAll && !f.featureWhitelist.Has(knownFeatureGate) {
+			continue
+		}
+
+		if featureGates.Enabled(knownFeatureGate) {
+			newConfigValue = append(newConfigValue, formatEnabledFunc(knownFeatureGate))
+		} else {
+			newConfigValue = append(newConfigValue, formatDisabledFunc(knownFeatureGate))
+		}
+	}
+
+	return newConfigValue
+}
+
+func StringsToFeatureGateNames(in []string) []configv1.FeatureGateName {
+	out := []configv1.FeatureGateName{}
+	for _, curr := range in {
+		out = append(out, configv1.FeatureGateName(curr))
+	}
+
+	return out
+}
+
+func FeatureGateNamesToStrings(in []configv1.FeatureGateName) []string {
+	out := []string{}
+	for _, curr := range in {
+		out = append(out, string(curr))
+	}
+
+	return out
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/simple_featuregate_reader.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/simple_featuregate_reader.go
@@ -1,0 +1,318 @@
+package featuregates
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"sync"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	v1 "github.com/openshift/client-go/config/informers/externalversions/config/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/operator/events"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+)
+
+type FeatureGateChangeHandlerFunc func(featureChange FeatureChange)
+
+// FeatureGateAccess is used to get a list of enabled and disabled featuregates.
+// Create a new instance using NewFeatureGateAccess.
+// To create one for unit testing, use NewHardcodedFeatureGateAccess.
+type FeatureGateAccess interface {
+	// SetChangeHandler can only be called before Run.
+	// The default change handler will exit 0 when the set of featuregates changes.
+	// That is usually the easiest and simplest thing for an *operator* to do.
+	// This also discourages direct operand reading since all operands restarting simultaneously is bad.
+	// This function allows changing that default behavior to something else (perhaps a channel notification for
+	// all impacted controllers in an operator.
+	// I doubt this will be worth the effort in the majority of cases.
+	SetChangeHandler(featureGateChangeHandlerFn FeatureGateChangeHandlerFunc)
+
+	// Run starts a go func that continously watches the set of featuregates enabled in the cluster.
+	Run(ctx context.Context)
+	// InitialFeatureGatesObserved returns a channel that is closed once the featuregates have
+	// been observed. Once closed, the CurrentFeatureGates method will return the current set of
+	// featuregates and will never return a non-nil error.
+	InitialFeatureGatesObserved() <-chan struct{}
+	// CurrentFeatureGates returns the list of enabled and disabled featuregates.
+	// It returns an error if the current set of featuregates is not known.
+	CurrentFeatureGates() (FeatureGate, error)
+	// AreInitialFeatureGatesObserved returns true if the initial featuregates have been observed.
+	AreInitialFeatureGatesObserved() bool
+}
+
+type Features struct {
+	Enabled  []configv1.FeatureGateName
+	Disabled []configv1.FeatureGateName
+}
+
+type FeatureChange struct {
+	Previous *Features
+	New      Features
+}
+
+type defaultFeatureGateAccess struct {
+	desiredVersion              string
+	missingVersionMarker        string
+	clusterVersionLister        configlistersv1.ClusterVersionLister
+	featureGateLister           configlistersv1.FeatureGateLister
+	initialFeatureGatesObserved chan struct{}
+
+	featureGateChangeHandlerFn FeatureGateChangeHandlerFunc
+
+	lock            sync.Mutex
+	started         bool
+	initialFeatures Features
+	currentFeatures Features
+
+	queue         workqueue.RateLimitingInterface
+	eventRecorder events.Recorder
+}
+
+// NewFeatureGateAccess returns a controller that keeps the list of enabled/disabled featuregates up to date.
+// desiredVersion is the version of this operator that would be set on the clusteroperator.status.versions.
+// missingVersionMarker is the stub version provided by the operator.  If that is also the desired version,
+// then the most either the desired clusterVersion or most recent version will be used.
+// clusterVersionInformer is used when desiredVersion and missingVersionMarker are the same to derive the "best" version
+// of featuregates to use.
+// featureGateInformer is used to track changes to the featureGates once they are initially set.
+// By default, when the enabled/disabled list  of featuregates changes, os.Exit is called.  This behavior can be
+// overridden by calling SetChangeHandler to whatever you wish the behavior to be.
+// A common construct is:
+/* go
+featureGateAccessor := NewFeatureGateAccess(args)
+go featureGateAccessor.Run(ctx)
+
+select{
+case <- featureGateAccessor.InitialFeatureGatesObserved():
+	featureGates, _ := featureGateAccessor.CurrentFeatureGates()
+	klog.Infof("FeatureGates initialized: knownFeatureGates=%v", featureGates.KnownFeatures())
+case <- time.After(1*time.Minute):
+	klog.Errorf("timed out waiting for FeatureGate detection")
+	return fmt.Errorf("timed out waiting for FeatureGate detection")
+}
+
+// whatever other initialization you have to do, at this point you have FeatureGates to drive your behavior.
+*/
+// That construct is easy.  It is better to use the .spec.observedConfiguration construct common in library-go operators
+// to avoid gating your general startup on FeatureGate determination, but if you haven't already got that mechanism
+// this construct is easy.
+func NewFeatureGateAccess(
+	desiredVersion, missingVersionMarker string,
+	clusterVersionInformer v1.ClusterVersionInformer,
+	featureGateInformer v1.FeatureGateInformer,
+	eventRecorder events.Recorder) FeatureGateAccess {
+	c := &defaultFeatureGateAccess{
+		desiredVersion:              desiredVersion,
+		missingVersionMarker:        missingVersionMarker,
+		clusterVersionLister:        clusterVersionInformer.Lister(),
+		featureGateLister:           featureGateInformer.Lister(),
+		initialFeatureGatesObserved: make(chan struct{}),
+		queue:                       workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "feature-gate-detector"),
+		eventRecorder:               eventRecorder,
+	}
+	c.SetChangeHandler(ForceExit)
+
+	// we aren't expecting many
+	clusterVersionInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			c.queue.Add("cluster")
+		},
+		UpdateFunc: func(old, cur interface{}) {
+			c.queue.Add("cluster")
+		},
+		DeleteFunc: func(uncast interface{}) {
+			c.queue.Add("cluster")
+		},
+	})
+	featureGateInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			c.queue.Add("cluster")
+		},
+		UpdateFunc: func(old, cur interface{}) {
+			c.queue.Add("cluster")
+		},
+		DeleteFunc: func(uncast interface{}) {
+			c.queue.Add("cluster")
+		},
+	})
+
+	return c
+}
+
+func ForceExit(featureChange FeatureChange) {
+	if featureChange.Previous != nil {
+		os.Exit(0)
+	}
+}
+
+func (c *defaultFeatureGateAccess) SetChangeHandler(featureGateChangeHandlerFn FeatureGateChangeHandlerFunc) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.started {
+		panic("programmer error, cannot update the change handler after starting")
+	}
+	c.featureGateChangeHandlerFn = featureGateChangeHandlerFn
+}
+
+func (c *defaultFeatureGateAccess) Run(ctx context.Context) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	klog.Infof("Starting feature-gate-detector")
+	defer klog.Infof("Shutting down feature-gate-detector")
+
+	go wait.UntilWithContext(ctx, c.runWorker, time.Second)
+
+	<-ctx.Done()
+}
+
+func (c *defaultFeatureGateAccess) syncHandler(ctx context.Context) error {
+	desiredVersion := c.desiredVersion
+	if c.missingVersionMarker == c.desiredVersion {
+		clusterVersion, err := c.clusterVersionLister.Get("version")
+		if apierrors.IsNotFound(err) {
+			return nil // we will be re-triggered when it is created
+		}
+		if err != nil {
+			return err
+		}
+
+		desiredVersion = clusterVersion.Status.Desired.Version
+		if len(desiredVersion) == 0 && len(clusterVersion.Status.History) > 0 {
+			desiredVersion = clusterVersion.Status.History[0].Version
+		}
+	}
+
+	featureGate, err := c.featureGateLister.Get("cluster")
+	if apierrors.IsNotFound(err) {
+		return nil // we will be re-triggered when it is created
+	}
+	if err != nil {
+		return err
+	}
+
+	features, err := featuresFromFeatureGate(featureGate, desiredVersion)
+	if err != nil {
+		return fmt.Errorf("unable to determine features: %w", err)
+	}
+
+	c.setFeatureGates(features)
+
+	return nil
+}
+
+func (c *defaultFeatureGateAccess) setFeatureGates(features Features) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	var previousFeatures *Features
+	if c.AreInitialFeatureGatesObserved() {
+		t := c.currentFeatures
+		previousFeatures = &t
+	}
+
+	c.currentFeatures = features
+
+	if !c.AreInitialFeatureGatesObserved() {
+		c.initialFeatures = features
+		close(c.initialFeatureGatesObserved)
+		c.eventRecorder.Eventf("FeatureGatesInitialized", "FeatureGates updated to %#v", c.currentFeatures)
+	}
+
+	if previousFeatures == nil || !reflect.DeepEqual(*previousFeatures, c.currentFeatures) {
+		if previousFeatures != nil {
+			c.eventRecorder.Eventf("FeatureGatesModified", "FeatureGates updated to %#v", c.currentFeatures)
+		}
+
+		c.featureGateChangeHandlerFn(FeatureChange{
+			Previous: previousFeatures,
+			New:      c.currentFeatures,
+		})
+	}
+}
+
+func (c *defaultFeatureGateAccess) InitialFeatureGatesObserved() <-chan struct{} {
+	return c.initialFeatureGatesObserved
+}
+
+func (c *defaultFeatureGateAccess) AreInitialFeatureGatesObserved() bool {
+	select {
+	case <-c.InitialFeatureGatesObserved():
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *defaultFeatureGateAccess) CurrentFeatureGates() (FeatureGate, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if !c.AreInitialFeatureGatesObserved() {
+		return nil, fmt.Errorf("featureGates not yet observed")
+	}
+	retEnabled := make([]configv1.FeatureGateName, len(c.currentFeatures.Enabled))
+	retDisabled := make([]configv1.FeatureGateName, len(c.currentFeatures.Disabled))
+	copy(retEnabled, c.currentFeatures.Enabled)
+	copy(retDisabled, c.currentFeatures.Disabled)
+
+	return NewFeatureGate(retEnabled, retDisabled), nil
+}
+
+func (c *defaultFeatureGateAccess) runWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *defaultFeatureGateAccess) processNextWorkItem(ctx context.Context) bool {
+	dsKey, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(dsKey)
+
+	err := c.syncHandler(ctx)
+	if err == nil {
+		c.queue.Forget(dsKey)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
+	c.queue.AddRateLimited(dsKey)
+
+	return true
+}
+
+func featuresFromFeatureGate(featureGate *configv1.FeatureGate, desiredVersion string) (Features, error) {
+	found := false
+	features := Features{}
+	for _, featureGateValues := range featureGate.Status.FeatureGates {
+		if featureGateValues.Version != desiredVersion {
+			continue
+		}
+		found = true
+		for _, enabled := range featureGateValues.Enabled {
+			features.Enabled = append(features.Enabled, enabled.Name)
+		}
+		for _, disabled := range featureGateValues.Disabled {
+			features.Disabled = append(features.Disabled, disabled.Name)
+		}
+		break
+	}
+
+	if !found {
+		return Features{}, fmt.Errorf("missing desired version %q in featuregates.config.openshift.io/cluster", desiredVersion)
+	}
+
+	return features, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,7 +1,7 @@
 # github.com/NYTimes/gziphandler v1.1.1
 ## explicit; go 1.11
 github.com/NYTimes/gziphandler
-# github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df
+# github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230321174746-8dcc6526cfb1
 ## explicit; go 1.18
 github.com/antlr/antlr4/runtime/Go/antlr/v4
 # github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
@@ -142,8 +142,8 @@ github.com/grpc-ecosystem/go-grpc-prometheus
 github.com/grpc-ecosystem/grpc-gateway/v2/internal/httprule
 github.com/grpc-ecosystem/grpc-gateway/v2/runtime
 github.com/grpc-ecosystem/grpc-gateway/v2/utilities
-# github.com/imdario/mergo v0.3.7
-## explicit
+# github.com/imdario/mergo v0.3.15
+## explicit; go 1.13
 github.com/imdario/mergo
 # github.com/inconshreveable/mousetrap v1.1.0
 ## explicit; go 1.18
@@ -196,6 +196,7 @@ github.com/openshift/api/config/v1
 github.com/openshift/api/config/v1alpha1
 github.com/openshift/api/console
 github.com/openshift/api/console/v1
+github.com/openshift/api/features
 github.com/openshift/api/helm
 github.com/openshift/api/helm/v1beta1
 github.com/openshift/api/image
@@ -312,6 +313,7 @@ github.com/openshift/library-go/pkg/operator/certrotation
 github.com/openshift/library-go/pkg/operator/condition
 github.com/openshift/library-go/pkg/operator/configobserver
 github.com/openshift/library-go/pkg/operator/configobserver/apiserver
+github.com/openshift/library-go/pkg/operator/configobserver/featuregates
 github.com/openshift/library-go/pkg/operator/configobserver/proxy
 github.com/openshift/library-go/pkg/operator/csi/credentialsrequestcontroller
 github.com/openshift/library-go/pkg/operator/csi/csiconfigobservercontroller


### PR DESCRIPTION
[SPLAT-1637](https://issues.redhat.com/browse/SPLAT-1637)

### Changes
- Bumped openshift/api to get new feature gate
- Stubbed in initial changes to allow multi vcenter to prevent operator from becoming degraded.
- Move user/pass from env vars to csi config file due to not allowing multiple user/pass as env vars (messy).
- Enhanced CSI Config file for multi vcenter config and password for each due to needing ability to configure each vCenter with unique user/pass.
- Updated checks to include a connection for all vCenters.
- Updated Unit Test

### Prerequisites 
- https://github.com/openshift/cluster-storage-operator/pull/465
- https://github.com/openshift/api/pull/1842
- https://github.com/openshift/vmware-vsphere-csi-driver-operator/pull/227
- https://github.com/openshift/vmware-vsphere-csi-driver/pull/122

### Blocks
- https://github.com/openshift/installer/pull/8638

### Notes
There is a PR changing the config to a secret which helps me out with this PR.  I am setting user/pass in the csi config just like it and was about to change it from configmap to secret.  The PR is: https://github.com/openshift/vmware-vsphere-csi-driver-operator/pull/227