### PR TITLE
WIP: STOR-1767: Debug e2e-vsphere test (2)

### DIFF
--- a/pkg/operator/vspherecontroller/driver_starter.go
+++ b/pkg/operator/vspherecontroller/driver_starter.go
@@ -35,7 +35,7 @@ func (c *VSphereController) createCSIDriver() {
 		c.eventRecorder,
 	).WithLogLevelController().WithManagementStateController(
 		driverOperandName,
-		false,
+		true,
 	).WithStaticResourcesController(
 		"VMwareVSphereDriverStaticResourcesController",
 		c.kubeClient,


### PR DESCRIPTION
As a follow-up to PR#234, let's verify simple idea: setting `allowOperatorRemovedState=True` for vmware-vsphere-csi-driver-operator ruins cluster installation.