### PR TITLE
OCPBUGS-37201: Make sure credentials are wrapped in double quotes

### DIFF
--- a/assets/csi_cloud_config.ini
+++ b/assets/csi_cloud_config.ini
@@ -2,8 +2,6 @@
 
 [Global]
 cluster-id = "${CLUSTER_ID}"
-user = "${USER}"
-password = "${PASSWORD}"
 
 [VirtualCenter "${VCENTER}"]
 insecure-flag = "true"

--- a/pkg/operator/vspherecontroller/config_test.go
+++ b/pkg/operator/vspherecontroller/config_test.go
@@ -1,6 +1,9 @@
 package vspherecontroller
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestINIConfig(t *testing.T) {
 	tests := []struct {
@@ -71,6 +74,36 @@ password   = password123`,
 cluster-id = 1234
 user       = user1
 password   = newpassword`,
+		},
+		{
+			name: "Valid config preserving double quotes in user",
+			config: `[Global]
+cluster-id = 1234
+user       = user1
+password   = password123`,
+			section:       "Global",
+			key:           "user",
+			value:         fmt.Sprintf("%q", "user2"),
+			expectedError: false,
+			expectedString: `[Global]
+cluster-id = 1234
+user       = "user2"
+password   = password123`,
+		},
+		{
+			name: "Valid config preserving double quotes in password",
+			config: `[Global]
+cluster-id = 1234
+user       = user1
+password   = password123`,
+			section:       "Global",
+			key:           "password",
+			value:         fmt.Sprintf("%q", "newpassword"),
+			expectedError: false,
+			expectedString: `[Global]
+cluster-id = 1234
+user       = user1
+password   = "newpassword"`,
 		},
 		{
 			name: "Invalid config with unbalaced section",

--- a/pkg/operator/vspherecontroller/vspherecontroller.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller.go
@@ -671,26 +671,32 @@ func (c *VSphereController) applyClusterCSIDriverChange(
 	}
 
 	datacenters := strings.Join(dataCenterNames, ",")
-	user, password, err := getUserAndPassword(defaultNamespace, cloudCredSecretName, infra, c.configMapLister, c.apiClients.SecretInformer)
-	if err != nil {
-		return nil, err
-	}
-
 	for pattern, value := range map[string]string{
 		"${CLUSTER_ID}":              infra.Status.InfrastructureName,
 		"${VCENTER}":                 sourceCFG.Workspace.VCenterIP,
 		"${DATACENTERS}":             datacenters,
 		"${MIGRATION_DATASTORE_URL}": datastoreURL,
-		"${USER}":                    user,
-		"${PASSWORD}":                password,
 	} {
 		csiConfigString = strings.ReplaceAll(csiConfigString, pattern, value)
+	}
+
+	// Get vSphere credentials from secret
+	user, password, err := getUserAndPassword(defaultNamespace, cloudCredSecretName, infra, c.configMapLister, c.apiClients.SecretInformer)
+	if err != nil {
+		return nil, err
 	}
 
 	csiConfig, err := newINIConfig(csiConfigString)
 	if err != nil {
 		return nil, err
 	}
+
+	// This is a workaround to account for the fact that passwords may have
+	// symbols considered inline comments by the INI format. Essentially,
+	// we make sure that the passowrd is wrapped in double quotes, and follow
+	// the same approach with username.
+	csiConfig.Set("Global", "user", fmt.Sprintf("%q", user))
+	csiConfig.Set("Global", "password", fmt.Sprintf("%q", password))
 
 	topologyCategories := utils.GetTopologyCategories(clusterCSIDriver, infra)
 	if len(topologyCategories) > 0 {


### PR DESCRIPTION
The CSI driver uses the `gcfg` library to read the INI configuration file generated by this operator. However, that library will truncate passwords containing inline comments (like commas).

To avoid that, we make sure that the INI file we render contains credentials values wrapped in double quotes.

CC @openshift/storage 