### PR TITLE
OCPBUGS-37772: Disable CSI migration in multi-vCenter cluster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.22.1
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/fatih/color v1.7.0
+	github.com/google/go-cmp v0.6.0
 	github.com/openshift/api v0.0.0-20240724184751-84047ef4a2ce
 	github.com/openshift/build-machinery-go v0.0.0-20240419090851-af9c868bcf52
 	github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87
@@ -53,7 +54,6 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/cel-go v0.17.8 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20240722153945-304e4f0156b8 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/pkg/operator/driverfeaturescontroller.go
+++ b/pkg/operator/driverfeaturescontroller.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	cfgv1 "github.com/openshift/api/config/v1"
 	opv1 "github.com/openshift/api/operator/v1"
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	infralister "github.com/openshift/client-go/config/listers/config/v1"
@@ -19,6 +20,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
 	corelister "k8s.io/client-go/listers/core/v1"
+	"k8s.io/klog/v2"
 )
 
 type DriverFeaturesController struct {
@@ -84,9 +86,6 @@ func (d DriverFeaturesController) Sync(ctx context.Context, controllerContext fa
 		return nil
 	}
 
-	// We will eventually need infra object to get the cluster defaults
-	// TODO: Read the defaults from infra object.
-
 	clusterCSIDriver, err := d.clusterCSIDriverLister.Get(utils.VSphereDriverName)
 	if err != nil {
 		return err
@@ -101,11 +100,26 @@ func (d DriverFeaturesController) Sync(ctx context.Context, controllerContext fa
 
 	topologyCategories := utils.GetTopologyCategories(clusterCSIDriver, infra)
 	if len(topologyCategories) > 0 {
-		requiredData := defaultFeatureConfigMap.Data
-		requiredData["improved-volume-topology"] = "true"
-		defaultFeatureConfigMap.Data = requiredData
+		defaultFeatureConfigMap.Data["improved-volume-topology"] = "true"
+	}
+
+	if !isCSIMigrationSupported(infra) {
+		klog.V(4).Infof("Disabling CSI migration")
+		defaultFeatureConfigMap.Data["csi-migration"] = "false"
 	}
 
 	_, _, err = resourceapply.ApplyConfigMap(ctx, d.kubeClient.CoreV1(), controllerContext.Recorder(), defaultFeatureConfigMap)
 	return err
+}
+
+func isCSIMigrationSupported(infra *cfgv1.Infrastructure) bool {
+	// CSI migration is supported on all vSphere clusters unless they have 2 or more vCenters
+	if infra.Spec.PlatformSpec.VSphere == nil {
+		// Assume a default vSphere configuration with 1 vCenter
+		return true
+	}
+	if len(infra.Spec.PlatformSpec.VSphere.VCenters) > 1 {
+		return false
+	}
+	return true
 }

--- a/pkg/operator/driverfeaturescontroller_test.go
+++ b/pkg/operator/driverfeaturescontroller_test.go
@@ -1,0 +1,204 @@
+package operator
+
+import (
+	"context"
+	"maps"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	cfgv1 "github.com/openshift/api/config/v1"
+	opv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/vmware-vsphere-csi-driver-operator/assets"
+	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/testlib"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func setFeature(features map[string]string, name, value string) map[string]string {
+	newFeatures := maps.Clone(features)
+	newFeatures[name] = value
+	return newFeatures
+}
+
+func TestDriverFeaturesController_Sync(t *testing.T) {
+	csiDriver := &opv1.ClusterCSIDriver{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "csi.vsphere.vmware.com",
+		},
+		Spec: opv1.ClusterCSIDriverSpec{},
+	}
+	csiDriverWithTopology := &opv1.ClusterCSIDriver{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "csi.vsphere.vmware.com",
+		},
+		Spec: opv1.ClusterCSIDriverSpec{
+			DriverConfig: opv1.CSIDriverConfigSpec{
+				DriverType: opv1.VSphereDriverType,
+				VSphere: &opv1.VSphereCSIDriverConfigSpec{
+					TopologyCategories: []string{"region", "zone"},
+				},
+			},
+		},
+	}
+
+	infra := &cfgv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: cfgv1.InfrastructureSpec{
+			PlatformSpec: cfgv1.PlatformSpec{
+				Type:    cfgv1.VSpherePlatformType,
+				VSphere: &cfgv1.VSpherePlatformSpec{},
+			},
+		},
+	}
+	infraWithTopology := &cfgv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: cfgv1.InfrastructureSpec{
+			PlatformSpec: cfgv1.PlatformSpec{
+				Type: cfgv1.VSpherePlatformType,
+				VSphere: &cfgv1.VSpherePlatformSpec{
+					FailureDomains: []cfgv1.VSpherePlatformFailureDomainSpec{
+						{
+							Name:     "name1",
+							Region:   "region1",
+							Zone:     "zone1",
+							Topology: cfgv1.VSpherePlatformTopology{},
+						},
+						{
+							Name:     "name2",
+							Region:   "region2",
+							Zone:     "zone2",
+							Topology: cfgv1.VSpherePlatformTopology{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	infraWithVCenters := &cfgv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: cfgv1.InfrastructureSpec{
+			PlatformSpec: cfgv1.PlatformSpec{
+				Type: cfgv1.VSpherePlatformType,
+				VSphere: &cfgv1.VSpherePlatformSpec{
+					VCenters: []cfgv1.VSpherePlatformVCenterSpec{
+						{
+							Server: "vcenter1",
+							Port:   80,
+						},
+						{
+							Server: "vcenter1",
+							Port:   80,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	defaultFeatureGates := map[string]string{
+		"async-query-volume":                "true",
+		"block-volume-snapshot":             "true",
+		"cnsmgr-suspend-create-volume":      "true",
+		"csi-auth-check":                    "true",
+		"csi-migration":                     "true",
+		"csi-windows-support":               "true",
+		"improved-csi-idempotency":          "true",
+		"improved-volume-topology":          "false",
+		"list-volumes":                      "true",
+		"multi-vcenter-csi-topology":        "true",
+		"online-volume-extend":              "true",
+		"pv-to-backingdiskobjectid-mapping": "false",
+		"topology-preferential-datastores":  "true",
+		"trigger-csi-fullsync":              "false",
+		"use-csinode-id":                    "true",
+	}
+
+	tests := []struct {
+		name             string
+		infra            *cfgv1.Infrastructure
+		clusterCSIDriver *opv1.ClusterCSIDriver
+		expectedFeatures map[string]string
+	}{
+		{
+			name:             "No topology",
+			infra:            infra,
+			clusterCSIDriver: csiDriver,
+			expectedFeatures: defaultFeatureGates,
+		}, {
+			name:             "ClusterCSIDriver failureDomains",
+			infra:            infra,
+			clusterCSIDriver: csiDriverWithTopology,
+			expectedFeatures: setFeature(defaultFeatureGates, "improved-volume-topology", "true"),
+		}, {
+			name:             "Infrastructure failureDomains",
+			infra:            infraWithTopology,
+			clusterCSIDriver: csiDriver,
+			expectedFeatures: setFeature(defaultFeatureGates, "improved-volume-topology", "true"),
+		}, {
+			name:             "multiple vCenters",
+			infra:            infraWithVCenters,
+			clusterCSIDriver: csiDriver,
+			expectedFeatures: setFeature(defaultFeatureGates, "csi-migration", "false"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			configObjects := runtime.Object(test.infra)
+			commonAPIClient := testlib.NewFakeClients(
+				[]runtime.Object{},
+				testlib.MakeFakeDriverInstance(),
+				configObjects,
+			)
+			testlib.AddClusterCSIDriverClient(commonAPIClient, test.clusterCSIDriver)
+
+			featureConfigBytes, err := assets.ReadFile("vsphere_features_config.yaml")
+			if err != nil {
+				t.Fatalf("failed to parse vsphere_features_config.yaml: %v", err)
+			}
+
+			recorder := events.NewInMemoryRecorder("test")
+			d := NewDriverFeaturesController(
+				"test",
+				cloudConfigNamespace,
+				featureConfigBytes,
+				commonAPIClient.KubeClient,
+				commonAPIClient.KubeInformers,
+				commonAPIClient.OperatorClient,
+				commonAPIClient.ConfigInformers,
+				commonAPIClient.ClusterCSIDriverInformer,
+				recorder,
+			)
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			testlib.StartFakeInformer(commonAPIClient, stopCh)
+			testlib.WaitForSync(commonAPIClient, stopCh)
+
+			syncContext := factory.NewSyncContext("vsphere-controller", recorder)
+			ctx := context.Background()
+			if err := d.Sync(ctx, syncContext); err != nil {
+				t.Fatalf("Sync() error = %v", err)
+			}
+
+			configMap, err := commonAPIClient.KubeClient.CoreV1().ConfigMaps("openshift-cluster-csi-drivers").Get(ctx, "internal-feature-states.csi.vsphere.vmware.com", metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("failed to get configmap: %v", err)
+			}
+
+			if !reflect.DeepEqual(configMap.Data, test.expectedFeatures) {
+				t.Errorf("expected features %+v, got %+v", test.expectedFeatures, configMap.Data)
+				t.Errorf("human readable diff: %s", cmp.Diff(test.expectedFeatures, configMap.Data))
+			}
+		})
+	}
+}


### PR DESCRIPTION
CSI migration is not supported in clusters with multiple vCenters.

In addition, add some unit tests for `improved-volume-topology` feature.

`migration-datastore-url` is added/removed to/from the ini file based on nr. vCenters already:
https://github.com/openshift/vmware-vsphere-csi-driver-operator/blob/3358d00cf279c8abd53ae2267374ef66ed505356/pkg/operator/vspherecontroller/vspherecontroller.go#L732-L734

@openshift/storage 