### PR TITLE
OCPBUGS-38272: Restart CSI driver controller pod on config change

### DIFF
--- a/pkg/operator/vspherecontroller/driver_starter.go
+++ b/pkg/operator/vspherecontroller/driver_starter.go
@@ -126,12 +126,12 @@ func (c *VSphereController) createCSIDriver() {
 		),
 		csidrivercontrollerservicecontroller.WithSecretHashAnnotationHook(
 			defaultNamespace,
-			cloudCredSecretName,
+			metricsCertSecretName,
 			c.apiClients.SecretInformer,
 		),
 		csidrivercontrollerservicecontroller.WithSecretHashAnnotationHook(
 			defaultNamespace,
-			metricsCertSecretName,
+			driverConfigSecretName,
 			c.apiClients.SecretInformer,
 		),
 		csidrivercontrollerservicecontroller.WithReplicasHook(c.nodeLister),
@@ -149,7 +149,7 @@ func (c *VSphereController) createCSIDriver() {
 			trustedCAConfigMap,
 			c.apiClients.ConfigMapInformer,
 		),
-		WithSecretDaemonSetAnnotationHook("vsphere-csi-config-secret", defaultNamespace, c.apiClients.SecretInformer),
+		WithSecretDaemonSetAnnotationHook(driverConfigSecretName, defaultNamespace, c.apiClients.SecretInformer),
 	).WithServiceMonitorController(
 		"VMWareVSphereDriverServiceMonitorController",
 		c.apiClients.DynamicClient,

--- a/pkg/operator/vspherecontroller/vspherecontroller.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller.go
@@ -3,7 +3,6 @@ package vspherecontroller
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/api/features"
 	"regexp"
 	"sort"
 	"strings"
@@ -17,6 +16,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	ocpv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/features"
 	operatorapi "github.com/openshift/api/operator/v1"
 	infralister "github.com/openshift/client-go/config/listers/config/v1"
 	clustercsidriverlister "github.com/openshift/client-go/operator/listers/operator/v1"
@@ -75,6 +75,7 @@ const (
 	metricsCertSecretName             = "vmware-vsphere-csi-driver-controller-metrics-serving-cert"
 	webhookSecretName                 = "vmware-vsphere-csi-driver-webhook-secret"
 	trustedCAConfigMap                = "vmware-vsphere-csi-driver-trusted-ca-bundle"
+	driverConfigSecretName            = "vsphere-csi-config-secret"
 	defaultNamespace                  = "openshift-cluster-csi-drivers"
 	driverOperandName                 = "vmware-vsphere-csi-driver"
 	resyncDuration                    = 20 * time.Minute


### PR DESCRIPTION
Restart CSI driver controller Deployment when vsphere-csi-config-secret changes. And make a constant with the secret name.

The driver itself does not read vmware-vsphere-cloud-credentials, it's ready by the operator and translated into vsphere-csi-config-secret. So remove its secret hash from the controller.

cc @openshift/storage 