### PR TITLE
OCPBUGS-43417: Fix panic on nil infrastructure Spec.PlatformSpec.VSphere

### DIFF
--- a/pkg/operator/testlib/testlib.go
+++ b/pkg/operator/testlib/testlib.go
@@ -255,6 +255,12 @@ func GetInfraObject() *ocpv1.Infrastructure {
 	}
 }
 
+func GetInfraObjectWithEmptyPlatformSpec() *ocpv1.Infrastructure {
+	infra := GetInfraObject()
+	infra.Spec.PlatformSpec.VSphere = nil
+	return infra
+}
+
 func GetSingleFailureDomainInfra() *ocpv1.Infrastructure {
 	return &ocpv1.Infrastructure{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/testlib/vcsim_framework.go
+++ b/pkg/operator/testlib/vcsim_framework.go
@@ -59,7 +59,7 @@ func SetupSimulator(modelDir string, infra *ocpv1.Infrastructure) ([]*vclib.VSph
 	var models []*simulator.Model
 
 	createdVCs := make(map[string]*vclib.VSphereConnection)
-	if len(infra.Spec.PlatformSpec.VSphere.FailureDomains) > 0 {
+	if infra.Spec.PlatformSpec.VSphere != nil && len(infra.Spec.PlatformSpec.VSphere.FailureDomains) > 0 {
 		fmt.Printf("Adding connections via FD\n")
 		for _, fd := range infra.Spec.PlatformSpec.VSphere.FailureDomains {
 			if createdVCs[fd.Server] == nil {

--- a/pkg/operator/vspherecontroller/vspherecontroller_test.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller_test.go
@@ -135,6 +135,27 @@ func TestSync(t *testing.T) {
 			storageClassCreated: true,
 		},
 		{
+			name:                         "infrastructure with empty platformSpec.vSphere does not crash the operator",
+			clusterCSIDriverObject:       testlib.MakeFakeDriverInstance(),
+			vcenterVersion:               "7.0.2",
+			hostVersion:                  "7.0.2",
+			startingNodeHardwareVersions: []string{"vmx-15", "vmx-15"},
+			initialObjects:               []runtime.Object{testlib.GetConfigMap(), testlib.GetSecret()},
+			infra:                        testlib.GetInfraObjectWithEmptyPlatformSpec(),
+			expectedConditions: []opv1.OperatorCondition{
+				{
+					Type:   testControllerName + opv1.OperatorStatusTypeUpgradeable,
+					Status: opv1.ConditionTrue,
+				},
+				{
+					Type:   "VMwareVSphereOperatorCheck" + opv1.OperatorStatusTypeDegraded,
+					Status: opv1.ConditionFalse,
+				},
+			},
+			operandStarted:      true,
+			storageClassCreated: true,
+		},
+		{
 			name:                         "when all configuration is right YAML",
 			clusterCSIDriverObject:       testlib.MakeFakeDriverInstance(),
 			vcenterVersion:               "7.0.2",


### PR DESCRIPTION
Convert the legacy ini file config to infrastructure not only when `VSphere.VCenters` is empty, but also when VSphere itself is nil.

This happens when the infrastructure was created by OCP 4.10 and older.

And make sure the operator does not overwrite the infrastructure in informer cache.

cc @openshift/storage 