### PR TITLE
OCPBUGS-45563: Move SyncRemove to AbstractStorageClass

### DIFF
--- a/pkg/operator/storageclasscontroller/multivcenterstorageclasscontroller.go
+++ b/pkg/operator/storageclasscontroller/multivcenterstorageclasscontroller.go
@@ -2,13 +2,14 @@ package storageclasscontroller
 
 import (
 	"context"
+	"time"
+
 	operatorapi "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/utils"
 	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/vclib"
 	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/vspherecontroller/checks"
 	"k8s.io/klog/v2"
-	"time"
 )
 
 type MultiVCenterStorageClassController struct {
@@ -16,12 +17,14 @@ type MultiVCenterStorageClassController struct {
 	connPolicyNames map[string]string // Key is vcenter name, value is policy name
 }
 
+var _ StorageClassSyncInterface = &MultiVCenterStorageClassController{}
+
 func makeMultiVCenterStorageClassController(abstract AbstractStorageClass) *MultiVCenterStorageClassController {
 	scc := MultiVCenterStorageClassController{
 		AbstractStorageClass: abstract,
 		connPolicyNames:      make(map[string]string),
 	}
-	scc.AbstractStorageClass.StorageClassSyncInterface = &scc
+	scc.StorageClassSyncInterface = &scc
 	return &scc
 }
 

--- a/pkg/operator/storageclasscontroller/storageclasscontroller.go
+++ b/pkg/operator/storageclasscontroller/storageclasscontroller.go
@@ -147,7 +147,7 @@ func (c *StorageClassController) Sync(ctx context.Context, connections []*vclib.
 	return c.updateConditions(ctx, checkResult, overallClusterStatus)
 }
 
-func (c *StorageClassController) SyncRemove(ctx context.Context) error {
+func (c *AbstractStorageClass) SyncRemove(ctx context.Context) error {
 	scString := string(c.manifest)
 	sc := resourceread.ReadStorageClassV1OrDie([]byte(scString))
 	_, _, err := resourceapply.DeleteStorageClass(ctx, c.kubeClient.StorageV1(), c.recorder, sc)


### PR DESCRIPTION
The patch fixes e2e-vsphere-operator-test. It failed before because vmware-vsphere-csi-driver-operator attempted to call non-existent SyncRemove method of MultiVCenterStorageClassController:
```
W1210 21:52:45.753900       1 vspherecontroller.go:183] VMwareVSphereController: ManagementState is Removed, skipping
runtime: goroutine stack exceeds 1000000000-byte limit
runtime: sp=0xc021d18378 stack=[0xc021d18000, 0xc041d18000]
fatal error: stack overflow
...
github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/storageclasscontroller.(*MultiVCenterStorageClassController).SyncRemove(0xc000cc65a0?, {0x3d138c8?, 0xc000af5e50?})
```
(see full logs [here](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_vmware-vsphere-csi-driver-operator/276/pull-ci-openshift-vmware-vsphere-csi-driver-operator-master-e2e-vsphere-operator-test/1866560677494132736/artifacts/e2e-vsphere-operator-test/gather-extra/artifacts/pods/openshift-cluster-csi-drivers_vmware-vsphere-csi-driver-operator-d98678cd6-x2wvs_vmware-vsphere-csi-driver-operator_previous.log))