### PR TITLE
OCPBUGS-46089: List only linux nodes

### DIFF
--- a/pkg/operator/testlib/vcsim_framework.go
+++ b/pkg/operator/testlib/vcsim_framework.go
@@ -172,6 +172,9 @@ func DefaultNodes() []*v1.Node {
 	var nodes []*v1.Node
 	for _, vm := range DefaultVMs {
 		node := Node(vm.name, WithProviderID("vsphere://"+vm.uuid))
+		node.Labels = map[string]string{
+			"kubernetes.io/os": "linux",
+		}
 		nodes = append(nodes, node)
 	}
 	return nodes

--- a/pkg/operator/vspherecontroller/checks/api_interface.go
+++ b/pkg/operator/vspherecontroller/checks/api_interface.go
@@ -4,14 +4,15 @@ import (
 	ocpv1 "github.com/openshift/api/config/v1"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	corelister "k8s.io/client-go/listers/core/v1"
 	storagelister "k8s.io/client-go/listers/storage/v1"
 )
 
 type KubeAPIInterface interface {
-	// ListNodes returns list of all nodes in the cluster.
-	ListNodes() ([]*v1.Node, error)
+	// ListLinuxNodes returns list of all linux nodes in the cluster.
+	ListLinuxNodes() ([]*v1.Node, error)
 	GetCSIDriver(name string) (*storagev1.CSIDriver, error)
 	ListCSINodes() ([]*storagev1.CSINode, error)
 	GetStorageClass(name string) (*storagev1.StorageClass, error)
@@ -26,8 +27,18 @@ type KubeAPIInterfaceImpl struct {
 	StorageClassLister storagelister.StorageClassLister
 }
 
-func (k *KubeAPIInterfaceImpl) ListNodes() ([]*v1.Node, error) {
-	return k.NodeLister.List(labels.Everything())
+func getLinuxNodeSelector() labels.Selector {
+	labelSelector := metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"kubernetes.io/os": "linux",
+		},
+	}
+	selector, _ := metav1.LabelSelectorAsSelector(&labelSelector)
+	return selector
+}
+
+func (k *KubeAPIInterfaceImpl) ListLinuxNodes() ([]*v1.Node, error) {
+	return k.NodeLister.List(getLinuxNodeSelector())
 }
 
 func (k *KubeAPIInterfaceImpl) GetCSIDriver(name string) (*storagev1.CSIDriver, error) {

--- a/pkg/operator/vspherecontroller/checks/check_nodes.go
+++ b/pkg/operator/vspherecontroller/checks/check_nodes.go
@@ -173,7 +173,7 @@ func (n *NodeChecker) checkOnNode(workInfo nodeChannelWorkData) ClusterCheckResu
 }
 
 func (n *NodeChecker) Check(ctx context.Context, checkOpts CheckArgs) []ClusterCheckResult {
-	nodes, err := checkOpts.apiClient.ListNodes()
+	nodes, err := checkOpts.apiClient.ListLinuxNodes()
 	if err != nil {
 		reason := fmt.Errorf("error listing node objects: %v", err)
 		return []ClusterCheckResult{MakeClusterDegradedError(CheckStatusOpenshiftAPIError, reason)}
@@ -243,6 +243,7 @@ func (n *NodeChecker) getHost(ctx context.Context, checkOpts CheckArgs, hostRef 
 }
 
 func getVM(ctx context.Context, checkOpts CheckArgs, node *v1.Node) (*mo.VirtualMachine, error) {
+	klog.V(5).Infof("getVM: node.Name: %v", node.Name)
 	vmUUID := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(node.Spec.ProviderID, "vsphere://")))
 	for _, client := range checkOpts.vmConnection {
 		vmClient := client.Client.Client


### PR DESCRIPTION
The operaor needs to check only linux nodes. The customer reported that checks for Windows nodes fail because vspherecontroller unable to find VM by UUID.