### PR TITLE
OCPBUGS-46574: Escape backslash in vCenter username

### DIFF
--- a/pkg/operator/vspherecontroller/vspherecontroller_test.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller_test.go
@@ -1230,3 +1230,31 @@ func TestEscapeQuotesAndBackslashes(t *testing.T) {
 		})
 	}
 }
+
+func TestEscapeBackslashInUsername(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "The username format: userName@domain",
+			input:    `userName@domain`,
+			expected: `userName@domain`,
+		},
+		{
+			name:     "The username format: domainName\\userName",
+			input:    `domainName\userName`,
+			expected: `domainName\\userName`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := escapeQuotesAndBackslashes(tc.input)
+			if actual != tc.expected {
+				t.Fatalf("escapeQuotesAndBackslashes(%q) = %q; expected %q", tc.input, actual, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
VMWare/Broadcom docs requre double backslash in the username:

> You must specify the username along with the domain name.
> For example, user = "userName@domainName" or user = "domainName\\\\username".

(https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/3.0/vmware-vsphere-csp-getting-started/GUID-BFF39F1D-F70A-4360-ABC9-85BDAFBE8864.html)