### PR TITLE
OCPBUGS-43273: fix panic when vcenter address is incorrect

### DIFF
--- a/pkg/operator/vspherecontroller/vspherecontroller.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller.go
@@ -501,7 +501,10 @@ func (c *VSphereController) createVCenterConnection(ctx context.Context, infra *
 			return fmt.Errorf("error parsing secret %q: key %q not found", cloudCredSecretName, passwordKey)
 		}
 
-		vs := vclib.NewVSphereConnection(string(username), string(password), vcenter.Server, c.cloudConfig)
+		vs, err := vclib.NewVSphereConnection(string(username), string(password), vcenter.Server, c.cloudConfig)
+		if err != nil {
+			return fmt.Errorf("error creating new vsphere connection: %v", err)
+		}
 		c.vSphereConnections = append(c.vSphereConnections, vs)
 	}
 	return nil


### PR DESCRIPTION
When address of vcenter was set incorrectly, the code would throw runtime error, this PR fixes it.

cc @openshift/storage 