### PR TITLE
OCPBUGS-49406: Set reconcile-sync to 10 minute for ListVolume

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -182,6 +182,7 @@ spec:
             - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
             - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
             - --v=${LOG_LEVEL}
+            - --reconcile-sync=10m
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock


### PR DESCRIPTION
Cherry-pick upstream [PR#3015](https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3015) for https://issues.redhat.com/browse/OCPBUGS-49406.

cc @openshift/storage