### PR TITLE
STOR-2245: add manifest-topology.yaml for topology related feature and test

### DIFF
--- a/test/e2e/manifest-topology.yaml
+++ b/test/e2e/manifest-topology.yaml
@@ -1,4 +1,3 @@
-# TODO: make sure this is the ideal configuration
 StorageClass:
   FromExistingClassName: thin-csi
 SnapshotClass:
@@ -13,6 +12,7 @@ DriverInfo:
   SupportedSizeRange:
     Min: 1Gi
     Max: 64Ti
+  TopologyKeys: ["topology.csi.vmware.com/openshift-zone"]
   Capabilities:
     persistence: true
     fsGroup: true
@@ -22,6 +22,7 @@ DriverInfo:
     controllerExpansion: true
     nodeExpansion: true
     snapshotDataSource: false
+    topology: true
     multipods: false
     multiplePVsSameID: false
     readWriteOncePod: true


### PR DESCRIPTION
When adding the multi-zone/multi-vcenter CI, some cases will check if there are at least 2 nodes in the same zone and need the topology Capability. 
The other profile that doesn't have the zonal configuration will still need the previous manifest. (The topology key is null)