### PR TITLE
OCPBUGS-62344: Fix escaping of password

### DIFF
--- a/pkg/operator/testlib/testlib.go
+++ b/pkg/operator/testlib/testlib.go
@@ -513,6 +513,20 @@ func GetMultiVCSecret() *v1.Secret {
 	}
 }
 
+// GetSecretWithPassword creates a secret with custom username and password for testing
+func GetSecretWithPassword(username, password string) *v1.Secret {
+	return &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: defaultNamespace,
+		},
+		Data: map[string][]byte{
+			"foobar.lan.password": []byte(password),
+			"foobar.lan.username": []byte(username),
+		},
+	}
+}
+
 func GetTestClusterResult(statusType checks.CheckStatusType) checks.ClusterCheckResult {
 	return checks.ClusterCheckResult{
 		CheckError:  fmt.Errorf("some error"),

--- a/pkg/operator/vspherecontroller/vspherecontroller.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller.go
@@ -725,7 +725,7 @@ func (c *VSphereController) applyClusterCSIDriverChange(
 		vcenterStr := string(csiVCenterConfigBytes)
 		vcenter := config.VirtualCenter[vcenterKey]
 
-		user, password, err := getUserAndPassword(defaultNamespace, cloudCredSecretName, vcenter.VCenterIP, infra, c.configMapLister, c.apiClients.SecretInformer, c.featureGates)
+		user, password, err := getUserAndPassword(defaultNamespace, cloudCredSecretName, vcenter.VCenterIP, c.apiClients.SecretInformer)
 		if err != nil {
 			return nil, err
 		}
@@ -792,8 +792,7 @@ func (c *VSphereController) createStorageClassController() storageclasscontrolle
 	return storageClassController
 }
 
-func getUserAndPassword(namespace string, secretName string, vcenter string, infra *ocpv1.Infrastructure, configMapLister corelister.ConfigMapLister, secretInformer corev1informers.SecretInformer, featureGates featuregates.FeatureGate,
-) (string, string, error) {
+func getUserAndPassword(namespace string, secretName string, vcenter string, secretInformer corev1informers.SecretInformer) (string, string, error) {
 	secret, err := secretInformer.Lister().Secrets(namespace).Get(secretName)
 	if err != nil {
 		return "", "", err

--- a/pkg/operator/vspherecontroller/vspherecontroller_test.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller_test.go
@@ -1281,7 +1281,7 @@ func TestEscapeQuotesAndBackslashes(t *testing.T) {
 		{
 			name:     "Already escaped",
 			input:    `Pass\"word\\1234\"`,
-			expected: `Pass\"word\\1234\"`,
+			expected: `Pass\\\"word\\\\1234\\\"`,
 		},
 		{
 			name:     "Only quotes",
@@ -1302,10 +1302,7 @@ func TestEscapeQuotesAndBackslashes(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := escapeQuotesAndBackslashes(tc.input)
-			if err != nil {
-				t.Fatalf("escapeQuotesAndBackslashes(%q) failed with error: %v", tc.input, err)
-			}
+			actual := escapeQuotesAndBackslashes(tc.input)
 			if actual != tc.expected {
 				t.Fatalf("escapeQuotesAndBackslashes(%q) = %q; expected %q", tc.input, actual, tc.expected)
 			}
@@ -1333,10 +1330,7 @@ func TestEscapeBackslashInUsername(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := escapeQuotesAndBackslashes(tc.input)
-			if err != nil {
-				t.Fatalf("escapeQuotesAndBackslashes(%q) failed with error: %v", tc.input, err)
-			}
+			actual := escapeBackslashInUsername(tc.input)
 			if actual != tc.expected {
 				t.Fatalf("escapeQuotesAndBackslashes(%q) = %q; expected %q", tc.input, actual, tc.expected)
 			}

--- a/pkg/operator/vspherecontroller/vspherecontroller_test.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller_test.go
@@ -18,11 +18,13 @@ import (
 	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/utils"
 	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/vclib"
 	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/vspherecontroller/checks"
+	"gopkg.in/gcfg.v1"
 	iniv1 "gopkg.in/ini.v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/metrics/testutil"
+	legacy "k8s.io/legacy-cloud-providers/vsphere"
 	"k8s.io/utils/clock"
 )
 
@@ -798,15 +800,16 @@ func TestApplyClusterCSIDriver(t *testing.T) {
 	featureGates := featuregates.NewFeatureGate([]configv1.FeatureGateName{"SomeEnabledFeatureGate"}, []configv1.FeatureGateName{"SomeDisabledFeatureGate"})
 
 	tests := []struct {
-		name                  string
-		clusterCSIDriver      *opv1.ClusterCSIDriver
-		operatorObj           *testlib.FakeDriverInstance
-		expectedTopology      string
-		configFileName        string
-		secretData            runtime.Object
-		checkMigrationURL     bool
-		expectedDatacenterMap map[string]string
-		expectError           bool
+		name                    string
+		clusterCSIDriver        *opv1.ClusterCSIDriver
+		operatorObj             *testlib.FakeDriverInstance
+		expectedTopology        string
+		configFileName          string
+		secretData              runtime.Object
+		checkMigrationURL       bool
+		expectedDatacenterMap   map[string]string
+		expectError             bool
+		expectedSnapshotOptions map[string]string
 	}{
 		{
 			name:             "when driver does not have topology enabled",
@@ -866,6 +869,64 @@ func TestApplyClusterCSIDriver(t *testing.T) {
 			},
 			expectedTopology:  "k8s-zone,k8s-region",
 			checkMigrationURL: true,
+		},
+		{
+			name: "when driver has snapshot options configured - all options",
+			clusterCSIDriver: func() *opv1.ClusterCSIDriver {
+				driver := testlib.GetClusterCSIDriver(false)
+				globalMax := uint32(10)
+				vsanMax := uint32(5)
+				vvolMax := uint32(3)
+				driver.Spec.DriverConfig.VSphere = &opv1.VSphereCSIDriverConfigSpec{
+					GlobalMaxSnapshotsPerBlockVolume:         &globalMax,
+					GranularMaxSnapshotsPerBlockVolumeInVSAN: &vsanMax,
+					GranularMaxSnapshotsPerBlockVolumeInVVOL: &vvolMax,
+				}
+				return driver
+			}(),
+			operatorObj: testlib.MakeFakeDriverInstance(),
+			secretData:  testlib.GetDCSecret(),
+			expectedDatacenterMap: map[string]string{
+				"foobar.lan": "Datacenter",
+			},
+			expectedTopology:  "",
+			checkMigrationURL: true,
+			expectedSnapshotOptions: map[string]string{
+				"global-max-snapshots-per-block-volume":        "10",
+				"granular-max-snapshots-per-block-volume-vsan": "5",
+				"granular-max-snapshots-per-block-volume-vvol": "3",
+			},
+		},
+		{
+			name: "when driver has snapshot options configured - partial options",
+			clusterCSIDriver: func() *opv1.ClusterCSIDriver {
+				driver := testlib.GetClusterCSIDriver(true)
+				globalMax := uint32(20)
+				driver.Spec.DriverConfig.VSphere.GlobalMaxSnapshotsPerBlockVolume = &globalMax
+				return driver
+			}(),
+			operatorObj: testlib.MakeFakeDriverInstance(),
+			secretData:  testlib.GetDCSecret(),
+			expectedDatacenterMap: map[string]string{
+				"foobar.lan": "Datacenter",
+			},
+			expectedTopology:  "k8s-zone,k8s-region",
+			checkMigrationURL: true,
+			expectedSnapshotOptions: map[string]string{
+				"global-max-snapshots-per-block-volume": "20",
+			},
+		},
+		{
+			name:             "when driver has no snapshot options",
+			clusterCSIDriver: testlib.GetClusterCSIDriver(true),
+			operatorObj:      testlib.MakeFakeDriverInstance(),
+			secretData:       testlib.GetDCSecret(),
+			expectedDatacenterMap: map[string]string{
+				"foobar.lan": "Datacenter",
+			},
+			expectedTopology:        "k8s-zone,k8s-region",
+			checkMigrationURL:       true,
+			expectedSnapshotOptions: nil,
 		},
 	}
 
@@ -944,6 +1005,38 @@ func TestApplyClusterCSIDriver(t *testing.T) {
 				}
 				if datastoreURL.String() != "foobar" {
 					t.Fatalf("expected datastoreURL to be %s got %s", "foobar", datastoreURL)
+				}
+			}
+
+			// Verify snapshot options
+			snapshotSection := csiConfig.Section("Snapshot")
+			if tc.expectedSnapshotOptions == nil {
+				// If no snapshot options expected, verify section doesn't exist or is empty
+				if snapshotSection != nil && len(snapshotSection.Keys()) > 0 {
+					t.Fatalf("unexpected snapshot section found with keys: %v", snapshotSection.KeyStrings())
+				}
+			} else {
+				// Verify snapshot section exists
+				if snapshotSection == nil {
+					t.Fatalf("expected Snapshot section not found in config")
+				}
+
+				// Verify each expected snapshot option
+				for expectedKey, expectedValue := range tc.expectedSnapshotOptions {
+					key, err := snapshotSection.GetKey(expectedKey)
+					if err != nil {
+						t.Fatalf("expected snapshot option %q not found: %v", expectedKey, err)
+					}
+					actualValue := key.String()
+					if actualValue != expectedValue {
+						t.Fatalf("snapshot option %q: expected value %q, got %q", expectedKey, expectedValue, actualValue)
+					}
+				}
+
+				// Verify no unexpected keys in snapshot section
+				actualKeys := snapshotSection.KeyStrings()
+				if len(actualKeys) != len(tc.expectedSnapshotOptions) {
+					t.Fatalf("expected %d snapshot options, found %d: %v", len(tc.expectedSnapshotOptions), len(actualKeys), actualKeys)
 				}
 			}
 		})
@@ -1188,7 +1281,7 @@ func TestEscapeQuotesAndBackslashes(t *testing.T) {
 		{
 			name:     "Already escaped",
 			input:    `Pass\"word\\1234\"`,
-			expected: `Pass\\\"word\\\\1234\\\"`,
+			expected: `Pass\"word\\1234\"`,
 		},
 		{
 			name:     "Only quotes",
@@ -1209,7 +1302,10 @@ func TestEscapeQuotesAndBackslashes(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := escapeQuotesAndBackslashes(tc.input)
+			actual, err := escapeQuotesAndBackslashes(tc.input)
+			if err != nil {
+				t.Fatalf("escapeQuotesAndBackslashes(%q) failed with error: %v", tc.input, err)
+			}
 			if actual != tc.expected {
 				t.Fatalf("escapeQuotesAndBackslashes(%q) = %q; expected %q", tc.input, actual, tc.expected)
 			}
@@ -1237,7 +1333,10 @@ func TestEscapeBackslashInUsername(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := escapeQuotesAndBackslashes(tc.input)
+			actual, err := escapeQuotesAndBackslashes(tc.input)
+			if err != nil {
+				t.Fatalf("escapeQuotesAndBackslashes(%q) failed with error: %v", tc.input, err)
+			}
 			if actual != tc.expected {
 				t.Fatalf("escapeQuotesAndBackslashes(%q) = %q; expected %q", tc.input, actual, tc.expected)
 			}
@@ -1246,243 +1345,180 @@ func TestEscapeBackslashInUsername(t *testing.T) {
 }
 
 // TestPasswordSerializationDeserialization tests that passwords with special characters
-// can be correctly serialized into an INI file embedded in a secret and then deserialized.
-// This specifically tests passwords containing backslashes, backticks, single quotes, and double quotes.
+// can be correctly serialized into an INI file embedded in a secret and then deserialized using gcfg.
+// This test uses the actual production code path via applyClusterCSIDriverChange.
 func TestPasswordSerializationDeserialization(t *testing.T) {
+	featureGates := featuregates.NewFeatureGate([]configv1.FeatureGateName{"SomeEnabledFeatureGate"}, []configv1.FeatureGateName{"SomeDisabledFeatureGate"})
+
 	tests := []struct {
 		name     string
 		password string
+		username string
 	}{
 		{
 			name:     "password with backslashes",
 			password: `Pass\word\123`,
+			username: "admin",
 		},
 		{
 			name:     "password with backticks",
 			password: "Pass`word`123",
+			username: "user1",
 		},
 		{
 			name:     "password with single quotes",
 			password: `Pass'word'123`,
+			username: "testuser",
 		},
 		{
 			name:     "password with double quotes",
-			password: `Pass"word"123`,
+			password: `Pas/s"word"123`,
+			username: "admin@vsphere.local",
 		},
 		{
 			name:     "password with all special characters",
 			password: `Pass\word"123'abc` + "`def",
+			username: "svc-account",
 		},
 		{
 			name:     "password with only backslashes",
 			password: `\\\\\`,
+			username: "testuser",
 		},
 		{
 			name:     "password with only double quotes",
 			password: `"""""`,
+			username: "admin",
 		},
 		{
 			name:     "password with only backticks",
 			password: "``````",
+			username: "user@domain",
 		},
 		{
 			name:     "password with only single quotes",
 			password: `''''''`,
+			username: "testaccount",
 		},
 		{
 			name:     "password with mixed escaping sequences",
 			password: `P@ss\"w0rd\\123'abc"def` + "`ghi",
+			username: "complexuser",
 		},
 		{
 			name:     "password with backslash at end",
 			password: `Password123\`,
+			username: "admin",
 		},
 		{
 			name:     "password with quote at end",
 			password: `Password123"`,
+			username: "testuser",
 		},
 		{
 			name:     "password with backtick at end",
 			password: "Password123`",
+			username: "user1",
 		},
 		{
 			name:     "complex realistic password",
 			password: `P@ssw0rd!"#$%&'()*+,-./:;<=>?@[\]^_` + "`{|}~",
+			username: "administrator@vsphere.local",
 		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			// Step 1: Escape the password as the code does
-			escapedPassword := escapeQuotesAndBackslashes(tc.password)
-
-			// Step 2: Create an INI configuration string with the escaped password
-			// This simulates what happens in applyClusterCSIDriverChange
-			iniContent := fmt.Sprintf(`[VirtualCenter "test-vcenter.example.com"]
-insecure-flag = true
-datacenters = DC1
-password = "%s"
-user = "testuser"
-
-[Global]
-cluster-id = test-cluster
-`, escapedPassword)
-
-			// Step 3: Serialize this into a secret (simulating cloud.conf in the secret)
-			secretData := map[string][]byte{
-				"cloud.conf": []byte(iniContent),
-			}
-
-			// Step 4: Deserialize the INI from the secret (simulating what newINIConfig does)
-			configString := string(secretData["cloud.conf"])
-			cfg, err := newINIConfig(configString)
-			if err != nil {
-				t.Fatalf("Failed to deserialize INI config: %v", err)
-			}
-
-			// Step 5: Read the password back from the deserialized INI
-			section := cfg.file.Section(`VirtualCenter "test-vcenter.example.com"`)
-			if section == nil {
-				t.Fatalf("VirtualCenter section not found in deserialized config")
-			}
-
-			passwordKey := section.Key("password")
-			if passwordKey == nil {
-				t.Fatalf("password key not found in VirtualCenter section")
-			}
-
-			deserializedPassword := passwordKey.String()
-
-			// Step 6: Verify the deserialized password matches the original escaped password
-			// Note: PreserveSurroundedQuote: true means quotes are preserved in the value
-			expectedWithQuotes := fmt.Sprintf(`"%s"`, escapedPassword)
-			if deserializedPassword != expectedWithQuotes {
-				t.Errorf("Password mismatch after deserialization:\n  Original escaped: %q\n  Expected with quotes: %q\n  Deserialized:     %q", escapedPassword, expectedWithQuotes, deserializedPassword)
-			}
-
-			// Additional verification: ensure the INI can be re-serialized
-			var b strings.Builder
-			_, err = cfg.file.WriteTo(&b)
-			if err != nil {
-				t.Fatalf("Failed to re-serialize INI config: %v", err)
-			}
-
-			// Deserialize again to ensure round-trip works
-			cfg2, err := newINIConfig(b.String())
-			if err != nil {
-				t.Fatalf("Failed to deserialize re-serialized INI config: %v", err)
-			}
-
-			section2 := cfg2.file.Section(`VirtualCenter "test-vcenter.example.com"`)
-			if section2 == nil {
-				t.Fatalf("VirtualCenter section not found in re-deserialized config")
-			}
-
-			passwordKey2 := section2.Key("password")
-			if passwordKey2 == nil {
-				t.Fatalf("password key not found in re-deserialized VirtualCenter section")
-			}
-
-			deserializedPassword2 := passwordKey2.String()
-			if deserializedPassword2 != expectedWithQuotes {
-				t.Errorf("Password mismatch after round-trip:\n  Original escaped: %q\n  Expected with quotes: %q\n  Round-trip:       %q", escapedPassword, expectedWithQuotes, deserializedPassword2)
-			}
-		})
-	}
-}
-
-// TestUserPasswordSerializationInSecret tests the full flow of serializing user/password
-// into a secret's cloud.conf and deserializing it back, similar to what happens in production.
-func TestUserPasswordSerializationInSecret(t *testing.T) {
-	tests := []struct {
-		name     string
-		username string
-		password string
-	}{
 		{
-			name:     "domain username with backslash and complex password",
+			name:     "quote, blackslash, double quote and backtick",
+			password: "xx'xxx\\23\"4`5",
+			username: "svc-user",
+		},
+		{
+			name:     "quote, blackslash, double quote with byte format",
+			password: `xx'xxx23"4`,
+			username: "testuser",
+		},
+		{
+			name:     "with simple password",
+			password: "Password123",
+			username: "admin",
+		},
+		{
+			name:     "domain user with backslash and complex password",
 			username: `DOMAIN\username`,
 			password: `P@ss\word"123'` + "`abc",
 		},
-		{
-			name:     "email username with special password",
-			username: `user@domain.com`,
-			password: `Pas\"s\\word123`,
-		},
-		{
-			name:     "simple username with backslash password",
-			username: `admin`,
-			password: `\\\password\\\`,
-		},
-		{
-			name:     "username with quotes in password",
-			password: `"quoted"password"`,
-			username: `serviceaccount`,
-		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			// Process username and password as the code does
-			processedUser := escapeBackslashInUsername(tc.username)
-			processedPassword := escapeQuotesAndBackslashes(tc.password)
+			// Create a secret with the test password
+			secretData := testlib.GetSecretWithPassword(tc.username, tc.password)
+			infra := testlib.GetInfraObject()
+			clusterCSIDriver := testlib.GetClusterCSIDriver(false)
 
-			// Create INI content similar to what applyClusterCSIDriverChange creates
-			iniTemplate := `[Global]
-cluster-id = test-cluster-id
+			initialObjects := []runtime.Object{secretData}
+			commonApiClient := testlib.NewFakeClients(initialObjects, testlib.MakeFakeDriverInstance(), infra)
+			testlib.AddClusterCSIDriverClient(commonApiClient, clusterCSIDriver)
 
-[VirtualCenter "vcenter1.example.com"]
-insecure-flag = true
-datacenters = DC1,DC2
-password = "%s"
-user = "%s"
-`
-			iniContent := fmt.Sprintf(iniTemplate, processedPassword, processedUser)
+			stopCh := make(chan struct{})
+			defer close(stopCh)
 
-			// Simulate storing in secret
-			secret := &v1.Secret{
-				Data: map[string][]byte{
-					"cloud.conf": []byte(iniContent),
-				},
+			go testlib.StartFakeInformer(commonApiClient, stopCh)
+			if err := testlib.AddInitialObjects(append(initialObjects, clusterCSIDriver), commonApiClient); err != nil {
+				t.Fatalf("error adding initial objects: %v", err)
 			}
 
-			// Simulate reading from secret and deserializing
-			cloudConf := string(secret.Data["cloud.conf"])
-			cfg, err := newINIConfig(cloudConf)
+			testlib.WaitForSync(commonApiClient, stopCh)
+			ctrl := newVsphereControllerWithGates(commonApiClient, featureGates)
+
+			vsphereConfig, err := testlib.GetVSphereConfig("")
 			if err != nil {
-				t.Fatalf("Failed to deserialize cloud.conf from secret: %v", err)
+				t.Fatalf("error loading vsphere config: %v", err)
 			}
 
-			// Verify we can read back the values correctly
-			vcSection := cfg.file.Section(`VirtualCenter "vcenter1.example.com"`)
-			if vcSection == nil {
-				t.Fatalf("VirtualCenter section not found")
+			// Call the actual production function
+			secret, err := ctrl.applyClusterCSIDriverChange(infra, vsphereConfig, clusterCSIDriver, "foobar")
+			if err != nil {
+				t.Fatalf("applyClusterCSIDriverChange failed: %v", err)
 			}
 
-			readUser := vcSection.Key("user").String()
-			readPassword := vcSection.Key("password").String()
-
-			// Note: PreserveSurroundedQuote: true means quotes are preserved in the value
-			expectedUser := fmt.Sprintf(`"%s"`, processedUser)
-			expectedPassword := fmt.Sprintf(`"%s"`, processedPassword)
-
-			if readUser != expectedUser {
-				t.Errorf("Username mismatch:\n  Expected: %q\n  Got:      %q", expectedUser, readUser)
+			// Verify the secret was created
+			if secret == nil {
+				t.Fatal("expected secret to be created, got nil")
 			}
 
-			if readPassword != expectedPassword {
-				t.Errorf("Password mismatch:\n  Expected: %q\n  Got:      %q", expectedPassword, readPassword)
+			cloudConf := string(secret.Data["cloud.conf"])
+			if cloudConf == "" {
+				t.Fatal("cloud.conf is empty in secret")
 			}
 
-			// Verify the Global section is also readable
-			globalSection := cfg.file.Section("Global")
-			if globalSection == nil {
-				t.Fatalf("Global section not found")
+			// Parse with gcfg library (production code path - what the CSI driver does)
+			// Use FatalOnly to ignore warnings about unknown fields
+			var gcfgConfig legacy.VSphereConfig
+			err = gcfg.FatalOnly(gcfg.ReadStringInto(&gcfgConfig, cloudConf))
+			if err != nil {
+				t.Fatalf("Failed to deserialize cloud.conf with gcfg: %v\nConfig content:\n%s", err, cloudConf)
 			}
 
-			clusterID := globalSection.Key("cluster-id").String()
-			if clusterID != "test-cluster-id" {
-				t.Errorf("cluster-id mismatch: expected %q, got %q", "test-cluster-id", clusterID)
+			// Verify the VirtualCenter section was parsed
+			vcConfig, ok := gcfgConfig.VirtualCenter["foobar.lan"]
+			if !ok {
+				t.Fatalf("VirtualCenter section 'foobar.lan' not found in deserialized config")
+			}
+
+			// Verify the deserialized password matches the original password
+			// gcfg automatically unescapes the password, so it should match the original
+			if vcConfig.Password != tc.password {
+				t.Errorf("Password mismatch after production flow:\n  Original password: %q\n  Deserialized:      %q",
+					tc.password, vcConfig.Password)
+			}
+
+			// Verify the username matches
+			if vcConfig.User != tc.username {
+				t.Errorf("Username mismatch:\n  Expected: %q\n  Got:      %q", tc.username, vcConfig.User)
+			}
+
+			// Verify other fields are present
+			if vcConfig.Datacenters == "" {
+				t.Error("Datacenters field is empty")
 			}
 		})
 	}


### PR DESCRIPTION
This improves escaping of golang escape characters using json library.

Also serializing the ini file using `iniv1` library appears to be incompatible with gcfg for various formats.  We change the operator to use a handrolled version.  We test if result is parseable by gcfg.

All of existing tests are still passing and this appears to fix whole host of character escaping issues, so I think we should be good.
