### PR TITLE
{DO NOT REVIEW} OCPBUGS-84895: Fix password escaping

### DIFF
--- a/pkg/operator/testlib/testlib.go
+++ b/pkg/operator/testlib/testlib.go
@@ -513,6 +513,20 @@ func GetMultiVCSecret() *v1.Secret {
 	}
 }
 
+// GetSecretWithPassword creates a secret with custom username and password for testing
+func GetSecretWithPassword(username, password string) *v1.Secret {
+	return &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: defaultNamespace,
+		},
+		Data: map[string][]byte{
+			"foobar.lan.password": []byte(password),
+			"foobar.lan.username": []byte(username),
+		},
+	}
+}
+
 func GetTestClusterResult(statusType checks.CheckStatusType) checks.ClusterCheckResult {
 	return checks.ClusterCheckResult{
 		CheckError:  fmt.Errorf("some error"),

--- a/pkg/operator/vspherecontroller/vspherecontroller.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller.go
@@ -17,7 +17,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	ocpv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/api/features"
 	operatorapi "github.com/openshift/api/operator/v1"
 	infralister "github.com/openshift/client-go/config/listers/config/v1"
 	clustercsidriverlister "github.com/openshift/client-go/operator/listers/operator/v1"
@@ -731,21 +730,23 @@ func (c *VSphereController) applyClusterCSIDriverChange(
 		vcenterStr := string(csiVCenterConfigBytes)
 		vcenter := config.VirtualCenter[vcenterKey]
 
-		user, password, err := getUserAndPassword(defaultNamespace, cloudCredSecretName, vcenter.VCenterIP, infra, c.configMapLister, c.apiClients.SecretInformer, c.featureGates)
+		user, password, err := getUserAndPassword(vcenter.VCenterIP, c.apiClients.SecretInformer)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error getting user and password: %v", err)
 		}
+
+		escapedUser, escapedPassword := escapeUserAndPassword(user, password)
 
 		for pattern, value := range map[string]string{
 			"${VCENTER}":     vcenter.VCenterIP,
 			"${DATACENTERS}": vcenter.Datacenters,
-			"${PASSWORD}":    password,
-			"${USER}":        user,
+			"${PASSWORD}":    escapedPassword,
+			"${USER}":        escapedUser,
 		} {
 			vcenterStr = strings.ReplaceAll(vcenterStr, pattern, value)
 		}
 		if len(vCenterKeys) < 2 {
-			vcenterStr = fmt.Sprintf("%v\nmigration-datastore-url = %v", vcenterStr, datastoreURL)
+			vcenterStr = fmt.Sprintf("%v\nmigration-datastore-url = \"%v\"", vcenterStr, datastoreURL)
 		}
 		vcenters = vcenters + "\n" + vcenterStr
 	}
@@ -757,26 +758,23 @@ func (c *VSphereController) applyClusterCSIDriverChange(
 		csiConfigString = strings.ReplaceAll(csiConfigString, pattern, value)
 	}
 
-	csiConfig, err := newINIConfig(csiConfigString)
-	if err != nil {
-		return nil, err
-	}
-
 	topologyCategories := utils.GetTopologyCategories(clusterCSIDriver, infra)
 	if len(topologyCategories) > 0 {
 		topologyCategoryString := strings.Join(topologyCategories, ",")
-		csiConfig.Set("Labels", "topology-categories", topologyCategoryString)
+		csiConfigString = fmt.Sprintf("%v\n[Labels]\ntopology-categories = \"%v\"", csiConfigString, topologyCategoryString)
 	}
 
 	snapshotOptions := utils.GetSnapshotOptions(clusterCSIDriver)
 	if len(snapshotOptions) > 0 {
+		csiConfigString = fmt.Sprintf("%v\n[Snapshot]", csiConfigString)
 		for k, v := range snapshotOptions {
-			csiConfig.Set("Snapshot", k, v)
+			csiConfigString = fmt.Sprintf("%v\n%v = %v", csiConfigString, k, v)
 		}
 	}
+	csiConfigString = fmt.Sprintf("%v\n", csiConfigString)
 
 	requiredSecret := resourceread.ReadSecretV1OrDie(c.secretManifest)
-	requiredSecret.Data["cloud.conf"] = []byte(csiConfig.String())
+	requiredSecret.Data["cloud.conf"] = []byte(csiConfigString)
 	return requiredSecret, nil
 }
 
@@ -799,9 +797,8 @@ func (c *VSphereController) createStorageClassController() storageclasscontrolle
 	return storageClassController
 }
 
-func getUserAndPassword(namespace string, secretName string, vcenter string, infra *ocpv1.Infrastructure, configMapLister corelister.ConfigMapLister, secretInformer corev1informers.SecretInformer, featureGates featuregates.FeatureGate,
-) (string, string, error) {
-	secret, err := secretInformer.Lister().Secrets(namespace).Get(secretName)
+func getUserAndPassword(vcenter string, secretInformer corev1informers.SecretInformer) (string, string, error) {
+	secret, err := secretInformer.Lister().Secrets(defaultNamespace).Get(cloudCredSecretName)
 	if err != nil {
 		return "", "", err
 	}
@@ -813,14 +810,8 @@ func getUserAndPassword(namespace string, secretName string, vcenter string, inf
 	//   "vcenter.xyz.vmwarevmc.com.username": "***"
 	// }
 	// So we need to figure those keys out
-	var usernameKey, passwordKey string
-
-	if len(secret.Data) > 2 && !featureGates.Enabled(features.FeatureGateVSphereMultiVCenters) {
-		klog.Warningf("CSI driver can only connect to one vcenter, more than 1 set of credentials found for CSI driver")
-	}
-
-	usernameKey = vcenter + ".username"
-	passwordKey = vcenter + ".password"
+	usernameKey := vcenter + ".username"
+	passwordKey := vcenter + ".password"
 
 	if usernameKey == "" || passwordKey == "" {
 		return "", "", fmt.Errorf("could not find vSphere credentials in secret %s/%s", secret.Namespace, secret.Name)
@@ -829,12 +820,17 @@ func getUserAndPassword(namespace string, secretName string, vcenter string, inf
 	// Get username and pass from secret created by CCO
 	username := string(secret.Data[usernameKey])
 	password := string(secret.Data[passwordKey])
+	return username, password, nil
+}
 
-	// The CSI driver expects a password with any quotation marks and backslashes escaped.
-	// xref: https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/121
-	// The username in the format "domainName\userName" must be converted to "domainName\\userName"
-	// xref: https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/3.0/vmware-vsphere-csp-getting-started/GUID-BFF39F1D-F70A-4360-ABC9-85BDAFBE8864.html
-	return escapeBackslashInUsername(username), escapeQuotesAndBackslashes(password), nil
+// The CSI driver expects a password with any quotation marks and backslashes escaped.
+// xref: https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/121
+// The username in the format "domainName\userName" must be converted to "domainName\\userName"
+// xref: https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/3.0/vmware-vsphere-csp-getting-started/GUID-BFF39F1D-F70A-4360-ABC9-85BDAFBE8864.html
+func escapeUserAndPassword(username, password string) (string, string) {
+	escapedUserName := escapeBackslashInUsername(username)
+	escapedPassword := escapeQuotesAndBackslashes(password)
+	return escapedUserName, escapedPassword
 }
 
 // escapeQuotesAndBackslashes escapes double quotes and backslashes in the input string.

--- a/pkg/operator/vspherecontroller/vspherecontroller_test.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller_test.go
@@ -18,11 +18,13 @@ import (
 	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/utils"
 	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/vclib"
 	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/vspherecontroller/checks"
+	"gopkg.in/gcfg.v1"
 	iniv1 "gopkg.in/ini.v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/metrics/testutil"
+	legacy "k8s.io/legacy-cloud-providers/vsphere"
 	"k8s.io/utils/clock"
 )
 
@@ -794,16 +796,17 @@ func TestApplyClusterCSIDriver(t *testing.T) {
 	multiVCenterGateDisabled := featuregates.NewFeatureGate([]configv1.FeatureGateName{"SomeEnabledFeatureGate"}, []configv1.FeatureGateName{"SomeDisabledFeatureGate", features.FeatureGateVSphereMultiVCenters})
 
 	tests := []struct {
-		name                  string
-		clusterCSIDriver      *opv1.ClusterCSIDriver
-		operatorObj           *testlib.FakeDriverInstance
-		expectedTopology      string
-		configFileName        string
-		secretData            runtime.Object
-		featureGates          featuregates.FeatureGate
-		checkMigrationURL     bool
-		expectedDatacenterMap map[string]string
-		expectError           bool
+		name                    string
+		clusterCSIDriver        *opv1.ClusterCSIDriver
+		operatorObj             *testlib.FakeDriverInstance
+		expectedTopology        string
+		configFileName          string
+		secretData              runtime.Object
+		featureGates            featuregates.FeatureGate
+		checkMigrationURL       bool
+		expectedDatacenterMap   map[string]string
+		expectError             bool
+		expectedSnapshotOptions map[string]string
 	}{
 		{
 			name:             "when driver does not have topology enabled",
@@ -880,6 +883,64 @@ func TestApplyClusterCSIDriver(t *testing.T) {
 			},
 			expectedTopology:  "k8s-zone,k8s-region",
 			checkMigrationURL: true,
+		},
+		{
+			name: "when driver has snapshot options configured - all options",
+			clusterCSIDriver: func() *opv1.ClusterCSIDriver {
+				driver := testlib.GetClusterCSIDriver(false)
+				globalMax := uint32(10)
+				vsanMax := uint32(5)
+				vvolMax := uint32(3)
+				driver.Spec.DriverConfig.VSphere = &opv1.VSphereCSIDriverConfigSpec{
+					GlobalMaxSnapshotsPerBlockVolume:         &globalMax,
+					GranularMaxSnapshotsPerBlockVolumeInVSAN: &vsanMax,
+					GranularMaxSnapshotsPerBlockVolumeInVVOL: &vvolMax,
+				}
+				return driver
+			}(),
+			operatorObj: testlib.MakeFakeDriverInstance(),
+			secretData:  testlib.GetDCSecret(),
+			expectedDatacenterMap: map[string]string{
+				"foobar.lan": "Datacenter",
+			},
+			expectedTopology:  "",
+			checkMigrationURL: true,
+			expectedSnapshotOptions: map[string]string{
+				"global-max-snapshots-per-block-volume":        "10",
+				"granular-max-snapshots-per-block-volume-vsan": "5",
+				"granular-max-snapshots-per-block-volume-vvol": "3",
+			},
+		},
+		{
+			name: "when driver has snapshot options configured - partial options",
+			clusterCSIDriver: func() *opv1.ClusterCSIDriver {
+				driver := testlib.GetClusterCSIDriver(true)
+				globalMax := uint32(20)
+				driver.Spec.DriverConfig.VSphere.GlobalMaxSnapshotsPerBlockVolume = &globalMax
+				return driver
+			}(),
+			operatorObj: testlib.MakeFakeDriverInstance(),
+			secretData:  testlib.GetDCSecret(),
+			expectedDatacenterMap: map[string]string{
+				"foobar.lan": "Datacenter",
+			},
+			expectedTopology:  "k8s-zone,k8s-region",
+			checkMigrationURL: true,
+			expectedSnapshotOptions: map[string]string{
+				"global-max-snapshots-per-block-volume": "20",
+			},
+		},
+		{
+			name:             "when driver has no snapshot options",
+			clusterCSIDriver: testlib.GetClusterCSIDriver(true),
+			operatorObj:      testlib.MakeFakeDriverInstance(),
+			secretData:       testlib.GetDCSecret(),
+			expectedDatacenterMap: map[string]string{
+				"foobar.lan": "Datacenter",
+			},
+			expectedTopology:        "k8s-zone,k8s-region",
+			checkMigrationURL:       true,
+			expectedSnapshotOptions: nil,
 		},
 	}
 
@@ -963,6 +1024,38 @@ func TestApplyClusterCSIDriver(t *testing.T) {
 				}
 				if datastoreURL.String() != "foobar" {
 					t.Fatalf("expected datastoreURL to be %s got %s", "foobar", datastoreURL)
+				}
+			}
+
+			// Verify snapshot options
+			snapshotSection := csiConfig.Section("Snapshot")
+			if tc.expectedSnapshotOptions == nil {
+				// If no snapshot options expected, verify section doesn't exist or is empty
+				if snapshotSection != nil && len(snapshotSection.Keys()) > 0 {
+					t.Fatalf("unexpected snapshot section found with keys: %v", snapshotSection.KeyStrings())
+				}
+			} else {
+				// Verify snapshot section exists
+				if snapshotSection == nil {
+					t.Fatalf("expected Snapshot section not found in config")
+				}
+
+				// Verify each expected snapshot option
+				for expectedKey, expectedValue := range tc.expectedSnapshotOptions {
+					key, err := snapshotSection.GetKey(expectedKey)
+					if err != nil {
+						t.Fatalf("expected snapshot option %q not found: %v", expectedKey, err)
+					}
+					actualValue := key.String()
+					if actualValue != expectedValue {
+						t.Fatalf("snapshot option %q: expected value %q, got %q", expectedKey, expectedValue, actualValue)
+					}
+				}
+
+				// Verify no unexpected keys in snapshot section
+				actualKeys := snapshotSection.KeyStrings()
+				if len(actualKeys) != len(tc.expectedSnapshotOptions) {
+					t.Fatalf("expected %d snapshot options, found %d: %v", len(tc.expectedSnapshotOptions), len(actualKeys), actualKeys)
 				}
 			}
 		})
@@ -1219,6 +1312,11 @@ func TestEscapeQuotesAndBackslashes(t *testing.T) {
 			input:    `\\\\\`,
 			expected: `\\\\\\\\\\`,
 		},
+		{
+			name:     "quote, blackslash, double quote and backtick",
+			input:    "xx'xxx\\23\"4`5",
+			expected: "xx'xxx\\\\23\\\"4`5",
+		},
 	}
 
 	for _, tc := range tests {
@@ -1251,9 +1349,189 @@ func TestEscapeBackslashInUsername(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := escapeQuotesAndBackslashes(tc.input)
+			actual := escapeBackslashInUsername(tc.input)
 			if actual != tc.expected {
-				t.Fatalf("escapeQuotesAndBackslashes(%q) = %q; expected %q", tc.input, actual, tc.expected)
+				t.Fatalf("escapeBackslashInUsername(%q) = %q; expected %q", tc.input, actual, tc.expected)
+			}
+		})
+	}
+}
+
+// TestPasswordSerializationDeserialization tests that passwords with special characters
+// can be correctly serialized into an INI file embedded in a secret and then deserialized using gcfg.
+// This test uses the actual production code path via applyClusterCSIDriverChange.
+func TestPasswordSerializationDeserialization(t *testing.T) {
+	featureGates := featuregates.NewFeatureGate([]configv1.FeatureGateName{"SomeEnabledFeatureGate"}, []configv1.FeatureGateName{"SomeDisabledFeatureGate"})
+
+	tests := []struct {
+		name     string
+		password string
+		username string
+	}{
+		{
+			name:     "password with backslashes",
+			password: `Pass\word\123`,
+			username: "admin",
+		},
+		{
+			name:     "password with backticks",
+			password: "Pass`word`123",
+			username: "user1",
+		},
+		{
+			name:     "password with single quotes",
+			password: `Pass'word'123`,
+			username: "testuser",
+		},
+		{
+			name:     "password with double quotes",
+			password: `Pas/s"word"123`,
+			username: "admin@vsphere.local",
+		},
+		{
+			name:     "password with all special characters",
+			password: `Pass\word"123'abc` + "`def",
+			username: "svc-account",
+		},
+		{
+			name:     "password with only backslashes",
+			password: `\\\\\`,
+			username: "testuser",
+		},
+		{
+			name:     "password with only double quotes",
+			password: `"""""`,
+			username: "admin",
+		},
+		{
+			name:     "password with only backticks",
+			password: "``````",
+			username: "user@domain",
+		},
+		{
+			name:     "password with only single quotes",
+			password: `''''''`,
+			username: "testaccount",
+		},
+		{
+			name:     "password with mixed escaping sequences",
+			password: `P@ss\"w0rd\\123'abc"def` + "`ghi",
+			username: "complexuser",
+		},
+		{
+			name:     "password with backslash at end",
+			password: `Password123\`,
+			username: "admin",
+		},
+		{
+			name:     "password with quote at end",
+			password: `Password123"`,
+			username: "testuser",
+		},
+		{
+			name:     "password with backtick at end",
+			password: "Password123`",
+			username: "user1",
+		},
+		{
+			name:     "complex realistic password",
+			password: `P@ssw0rd!"#$%&'()*+,-./:;<=>?@[\]^_` + "`{|}~",
+			username: "administrator@vsphere.local",
+		},
+		{
+			name:     "quote, blackslash, double quote and backtick",
+			password: "xx'xxx\\23\"4`5",
+			username: "svc-user",
+		},
+		{
+			name:     "quote, blackslash, double quote with byte format",
+			password: `xx'xxx23"4`,
+			username: "testuser",
+		},
+		{
+			name:     "with simple password",
+			password: "Password123",
+			username: "admin",
+		},
+		{
+			name:     "domain user with backslash and complex password",
+			username: `DOMAIN\username`,
+			password: `P@ss\word"123'` + "`abc",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a secret with the test password
+			secretData := testlib.GetSecretWithPassword(tc.username, tc.password)
+			infra := testlib.GetInfraObject()
+			clusterCSIDriver := testlib.GetClusterCSIDriver(false)
+
+			initialObjects := []runtime.Object{secretData}
+			commonApiClient := testlib.NewFakeClients(initialObjects, testlib.MakeFakeDriverInstance(), infra)
+			testlib.AddClusterCSIDriverClient(commonApiClient, clusterCSIDriver)
+
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+
+			go testlib.StartFakeInformer(commonApiClient, stopCh)
+			if err := testlib.AddInitialObjects(append(initialObjects, clusterCSIDriver), commonApiClient); err != nil {
+				t.Fatalf("error adding initial objects: %v", err)
+			}
+
+			testlib.WaitForSync(commonApiClient, stopCh)
+			ctrl := newVsphereControllerWithGates(commonApiClient, featureGates)
+
+			vsphereConfig, err := testlib.GetVSphereConfig("")
+			if err != nil {
+				t.Fatalf("error loading vsphere config: %v", err)
+			}
+
+			// Call the actual production function
+			secret, err := ctrl.applyClusterCSIDriverChange(infra, vsphereConfig, clusterCSIDriver, "foobar")
+			if err != nil {
+				t.Fatalf("applyClusterCSIDriverChange failed: %v", err)
+			}
+
+			// Verify the secret was created
+			if secret == nil {
+				t.Fatal("expected secret to be created, got nil")
+			}
+
+			cloudConf := string(secret.Data["cloud.conf"])
+			if cloudConf == "" {
+				t.Fatal("cloud.conf is empty in secret")
+			}
+
+			// Parse with gcfg library (production code path - what the CSI driver does)
+			// Use FatalOnly to ignore warnings about unknown fields
+			var gcfgConfig legacy.VSphereConfig
+			err = gcfg.FatalOnly(gcfg.ReadStringInto(&gcfgConfig, cloudConf))
+			if err != nil {
+				t.Fatalf("Failed to deserialize cloud.conf with gcfg: %v\nConfig content:\n%s", err, cloudConf)
+			}
+
+			// Verify the VirtualCenter section was parsed
+			vcConfig, ok := gcfgConfig.VirtualCenter["foobar.lan"]
+			if !ok {
+				t.Fatalf("VirtualCenter section 'foobar.lan' not found in deserialized config")
+			}
+
+			// Verify the deserialized password matches the original password
+			// gcfg automatically unescapes the password, so it should match the original
+			if vcConfig.Password != tc.password {
+				t.Errorf("Password mismatch after production flow:\n  Original password: %q\n  Deserialized:      %q",
+					tc.password, vcConfig.Password)
+			}
+
+			// Verify the username matches
+			if vcConfig.User != tc.username {
+				t.Errorf("Username mismatch:\n  Expected: %q\n  Got:      %q", tc.username, vcConfig.User)
+			}
+
+			// Verify other fields are present
+			if vcConfig.Datacenters == "" {
+				t.Error("Datacenters field is empty")
 			}
 		})
 	}


### PR DESCRIPTION
Backport of #341 to release-4.18 with conflict resolution.

Replaces the gopkg.in/ini.v1-based config serialization with direct string formatting to avoid INI parsing issues with special characters (backslashes, double quotes) in passwords. Moves escaping into a separate escapeUserAndPassword helper called after getUserAndPassword, and wraps migration-datastore-url values in quotes to match the format expected by gcfg.