### PR TITLE
OCPBUGS-85345: Fixed hybrid env test to use disruptive / serial labels in title

### DIFF
--- a/openshift-tests/e2e/hybrid_environment.go
+++ b/openshift-tests/e2e/hybrid_environment.go
@@ -200,7 +200,7 @@ var _ = Describe("[sig-storage][OCPFeatureGate:VSphereMixedNodeEnv][platform:vsp
 			}
 		})
 
-		It("should degrade when ClusterCSIDriver is set to Managed in hybrid environment [Suite:openshift/conformance/serial]", Label("Serial"), ginkgo.Informing(), func() {
+		It("should degrade when ClusterCSIDriver is set to Managed in hybrid environment [Serial][Disruptive][Suite:openshift/conformance/serial]", Label("Serial"), ginkgo.Informing(), func() {
 			By("Checking if this is a hybrid environment")
 			nodesWithVSphereLabel, nodesWithoutLabel, err := categorizeNodesByPlatform(ctx, kubeClient, false)
 			Expect(err).NotTo(HaveOccurred(), "Failed to categorize nodes by platform")


### PR DESCRIPTION
[OCPBUGS-85345
](https://redhat.atlassian.net/browse/OCPBUGS-85345)
### Changes
- Changed hybrid_environment test "should degrade when ClusterCSIDriver is set to Managed in hybrid environment" to have disruptive and serial labels in title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test categorization for hybrid environment ClusterCSIDriver management scenario to mark it as serial and disruptive, ensuring proper test execution isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->