### PR TITLE
Add multi-vCenter and failure domain lifecycle support

### DIFF
--- a/pkg/operator/storageclasscontroller/storageclasscontroller.go
+++ b/pkg/operator/storageclasscontroller/storageclasscontroller.go
@@ -44,7 +44,7 @@ var (
 )
 
 type StorageClassSyncInterface interface {
-	Sync(ctx context.Context, connection *vclib.VSphereConnection, apiDeps checks.KubeAPIInterface) error
+	Sync(ctx context.Context, connMgr *vclib.VSphereConnectionManager, apiDeps checks.KubeAPIInterface) error
 }
 
 type StorageClassController struct {
@@ -96,12 +96,12 @@ func NewStorageClassController(
 	return c
 }
 
-func (c *StorageClassController) Sync(ctx context.Context, connection *vclib.VSphereConnection, apiDeps checks.KubeAPIInterface) error {
+func (c *StorageClassController) Sync(ctx context.Context, connMgr *vclib.VSphereConnectionManager, apiDeps checks.KubeAPIInterface) error {
 	checkResultFunc := func() (checks.ClusterCheckResult, checks.ClusterCheckStatus) {
 		sc := resourceread.ReadStorageClassV1OrDie(c.manifest)
 		scState := c.scStateEvaluator.GetStorageClassState(sc.Provisioner)
 
-		policyName, syncResult := c.syncStoragePolicy(ctx, connection, apiDeps, scState)
+		policyName, syncResult := c.syncStoragePolicy(ctx, connMgr, apiDeps, scState)
 		if syncResult.CheckError != nil {
 			klog.Errorf("error syncing storage policy: %v", syncResult.Reason)
 			clusterCondition := "storage_class_sync_failed"
@@ -122,7 +122,7 @@ func (c *StorageClassController) Sync(ctx context.Context, connection *vclib.VSp
 	return c.updateConditions(ctx, checkResult, overallClusterStatus)
 }
 
-func (c *StorageClassController) syncStoragePolicy(ctx context.Context, connection *vclib.VSphereConnection, apiDeps checks.KubeAPIInterface, scState operatorapi.StorageClassStateName) (string, checks.ClusterCheckResult) {
+func (c *StorageClassController) syncStoragePolicy(ctx context.Context, connMgr *vclib.VSphereConnectionManager, apiDeps checks.KubeAPIInterface, scState operatorapi.StorageClassStateName) (string, checks.ClusterCheckResult) {
 	// if the SC is not managed, there is no need to sync the storage policy
 	if !c.scStateEvaluator.IsManaged(scState) {
 		return "", checks.MakeClusterCheckResultPass()
@@ -136,7 +136,14 @@ func (c *StorageClassController) syncStoragePolicy(ctx context.Context, connecti
 	}
 
 	infra := apiDeps.GetInfrastructure()
+	// Use primary connection for backward compatibility with the factory function
+	connection := connMgr.GetPrimary()
 	apiClient := c.makeStoragePolicyAPI(ctx, connection, infra)
+
+	// Inject the connection manager into the API client if it supports it
+	if mgr, ok := apiClient.(connectionManagerAware); ok {
+		mgr.setConnectionManager(connMgr)
+	}
 
 	// we expect all API calls to finish within apiTimeout or else operator might be stuck
 	tctx, cancel := context.WithTimeout(ctx, apiTimeout)
@@ -151,7 +158,15 @@ func (c *StorageClassController) syncStoragePolicy(ctx context.Context, connecti
 	if err != nil {
 		return "", checks.MakeGenericVCenterAPIError(err)
 	}
+	// Reset backoff on success — next sync restarts at 1-minute interval
+	c.backoff = defaultBackoff
 	return policyName, checks.MakeClusterCheckResultPass()
+}
+
+// connectionManagerAware is an optional interface that vCenterInterface implementations
+// can support to receive the connection manager for multi-vCenter operations.
+type connectionManagerAware interface {
+	setConnectionManager(connMgr *vclib.VSphereConnectionManager)
 }
 
 func (c *StorageClassController) updateConditions(ctx context.Context, lastCheckResult checks.ClusterCheckResult, clusterStatus checks.ClusterCheckStatus) error {

--- a/pkg/operator/storageclasscontroller/storageclasscontroller_test.go
+++ b/pkg/operator/storageclasscontroller/storageclasscontroller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	v1 "github.com/openshift/api/config/v1"
 	opv1 "github.com/openshift/api/operator/v1"
@@ -40,6 +41,17 @@ func newFakeStoragePolicyAPISuccess(ctx context.Context, connection *vclib.VSphe
 func newFakeStoragePolicyAPIFailure(ctx context.Context, connection *vclib.VSphereConnection, infra *v1.Infrastructure) vCenterInterface {
 	fakeStoragePolicyAPI := &fakeStoragePolicyAPI{ret: "fake-return-value", err: fmt.Errorf("fake-error")}
 	return fakeStoragePolicyAPI
+}
+
+// newTestConnectionManager creates a minimal connection manager for testing.
+// The connection has a nil Client, which is fine because the storage policy API
+// is faked in tests and never actually connects to vCenter.
+func newTestConnectionManager() *vclib.VSphereConnectionManager {
+	connMgr := vclib.NewVSphereConnectionManager()
+	conn := &vclib.VSphereConnection{Hostname: "test-vcenter.example.com"}
+	connMgr.AddConnection("test-vcenter.example.com", conn)
+	connMgr.SetPrimary("test-vcenter.example.com")
+	return connMgr
 }
 
 func newStorageClassController(apiClients *utils.APIClient, storageclassfile string, storagePolicyAPIfailing bool) *StorageClassController {
@@ -160,14 +172,14 @@ func TestSync(t *testing.T) {
 			commonApiClient := testlib.NewFakeClients(test.initialObjects, test.clusterCSIDriverObject, test.configObjects)
 
 			apiDeps := getCheckAPIDependency(commonApiClient)
-			var conn *vclib.VSphereConnection
+			connMgr := newTestConnectionManager()
 			scController := newStorageClassController(commonApiClient, test.storageClass, test.StoragePolicyAPIfails)
 
 			if test.shouldPanic {
 				defer assertPanic(t)
 			}
 			// err will be nil on even on failure, need to check conditions instead
-			err := scController.Sync(context.TODO(), conn, apiDeps)
+			err := scController.Sync(context.TODO(), connMgr, apiDeps)
 			if err != nil {
 				t.Errorf("failed to sync controller: %+v", err)
 			}
@@ -219,12 +231,12 @@ func TestSyncMultiple(t *testing.T) {
 			commonApiClient := testlib.NewFakeClients(initialObjects, clusterCSIDriverObject, configObjects)
 			storageClass := "storageclass1.yaml"
 			apiDeps := getCheckAPIDependency(commonApiClient)
-			var conn *vclib.VSphereConnection
+			connMgr := newTestConnectionManager()
 			scController := newStorageClassController(commonApiClient, storageClass, test.storagePolicySyncFails)
 			scController.backoff = defaultBackoff
 
 			// err will be nil on even on failure, need to check conditions instead
-			policyName, clusterCheckResult := scController.syncStoragePolicy(context.TODO(), conn, apiDeps, opv1.ManagedStorageClass)
+			policyName, clusterCheckResult := scController.syncStoragePolicy(context.TODO(), connMgr, apiDeps, opv1.ManagedStorageClass)
 			scController.policyName = policyName
 
 			if test.expectError {
@@ -244,7 +256,7 @@ func TestSyncMultiple(t *testing.T) {
 				scController.makeStoragePolicyAPI = nil
 			}
 
-			policyName, clusterCheckResult = scController.syncStoragePolicy(context.TODO(), conn, apiDeps, opv1.ManagedStorageClass)
+			policyName, clusterCheckResult = scController.syncStoragePolicy(context.TODO(), connMgr, apiDeps, opv1.ManagedStorageClass)
 			if test.expectError {
 				if clusterCheckResult.CheckError == nil {
 					t.Errorf("Expected error got none")
@@ -255,6 +267,90 @@ func TestSyncMultiple(t *testing.T) {
 			} else {
 				if clusterCheckResult.CheckError != nil {
 					t.Errorf("Expected no error got: %v", clusterCheckResult.CheckError)
+				}
+			}
+		})
+	}
+}
+
+func TestBackoffReset(t *testing.T) {
+	tests := []struct {
+		name string
+		// sequence of sync results: true=success, false=failure
+		syncSequence []bool
+		// expected backoff duration after each sync (approximate, considering jitter)
+		expectedDurations []time.Duration
+	}{
+		{
+			name:         "success resets backoff to initial duration",
+			syncSequence: []bool{true, true, true},
+			// After each success, backoff resets to defaultBackoff, so Step() returns ~1min each time
+			expectedDurations: []time.Duration{time.Minute, time.Minute, time.Minute},
+		},
+		{
+			name:         "fail 3x then succeed resets backoff",
+			syncSequence: []bool{false, false, false, true, false},
+			// fail: 1m, fail: 2m, fail: 4m, success: 8m (then reset), fail: 1m (reset took effect)
+			expectedDurations: []time.Duration{time.Minute, 2 * time.Minute, 4 * time.Minute, 8 * time.Minute, time.Minute},
+		},
+		{
+			name:         "continuous failure caps at 30 minutes",
+			syncSequence: []bool{false, false, false, false, false, false, false},
+			// 1m, 2m, 4m, 8m, 16m, 30m (cap), 30m (cap)
+			expectedDurations: []time.Duration{
+				time.Minute, 2 * time.Minute, 4 * time.Minute, 8 * time.Minute,
+				16 * time.Minute, 30 * time.Minute, 30 * time.Minute,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			initialObjects := []runtime.Object{testlib.GetConfigMap(), testlib.GetSecret()}
+			clusterCSIDriverObject := testlib.MakeFakeDriverInstance()
+			configObjects := runtime.Object(testlib.GetInfraObject())
+			commonApiClient := testlib.NewFakeClients(initialObjects, clusterCSIDriverObject, configObjects)
+			apiDeps := getCheckAPIDependency(commonApiClient)
+			connMgr := newTestConnectionManager()
+
+			// Start with a success-producing controller
+			scController := newStorageClassController(commonApiClient, "storageclass1.yaml", false)
+			scController.backoff = defaultBackoff
+
+			for i, shouldSucceed := range test.syncSequence {
+				// Set up the right fake API for this iteration
+				if shouldSucceed {
+					scController.makeStoragePolicyAPI = newFakeStoragePolicyAPISuccess
+				} else {
+					scController.makeStoragePolicyAPI = newFakeStoragePolicyAPIFailure
+				}
+
+				// Force the check to run by resetting nextCheck
+				scController.nextCheck = time.Time{}
+				scController.policyName = ""
+
+				beforeSync := time.Now()
+				policyName, clusterCheckResult := scController.syncStoragePolicy(context.TODO(), connMgr, apiDeps, opv1.ManagedStorageClass)
+				scController.policyName = policyName
+
+				if shouldSucceed {
+					if clusterCheckResult.CheckError != nil {
+						t.Fatalf("step %d: expected success, got error: %v", i, clusterCheckResult.CheckError)
+					}
+				} else {
+					if clusterCheckResult.CheckError == nil {
+						t.Fatalf("step %d: expected error, got none", i)
+					}
+				}
+
+				// Verify the backoff duration by checking nextCheck - lastCheck
+				actualDelay := scController.nextCheck.Sub(beforeSync)
+				expectedDelay := test.expectedDurations[i]
+
+				// Allow 5% jitter tolerance (jitter is 0.01 = 1%)
+				tolerance := float64(expectedDelay) * 0.05
+				if actualDelay < expectedDelay-time.Duration(tolerance) || actualDelay > expectedDelay+time.Duration(tolerance) {
+					t.Errorf("step %d: expected delay ~%v, got %v", i, expectedDelay, actualDelay)
 				}
 			}
 		})

--- a/pkg/operator/storageclasscontroller/vmware.go
+++ b/pkg/operator/storageclasscontroller/vmware.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/utils"
 	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/vclib"
 
 	v1 "github.com/openshift/api/config/v1"
@@ -51,15 +52,26 @@ type vCenterInterface interface {
 
 type storagePolicyAPI struct {
 	vcenterApiConnection *vclib.VSphereConnection
+	connectionManager    *vclib.VSphereConnectionManager
 	tagManager           *tags.Manager
 	infra                *v1.Infrastructure
 	policyName           string
 	tagName              string
 	categoryName         string
 	policyCreated        bool
+	// Per-vCenter policy tracking. When using a connection manager,
+	// tracks whether the SPBM profile exists on each vCenter.
+	policyCreatedPerVC map[string]bool
 	// mainly used for verifying test status
 	// Keep track of mutable API calls being made
 	apiTestInfo map[string]int
+}
+
+func (v *storagePolicyAPI) setConnectionManager(connMgr *vclib.VSphereConnectionManager) {
+	v.connectionManager = connMgr
+	if v.policyCreatedPerVC == nil {
+		v.policyCreatedPerVC = make(map[string]bool)
+	}
 }
 
 var _ vCenterInterface = &storagePolicyAPI{}
@@ -130,7 +142,6 @@ func (v *storagePolicyAPI) getDatastore(ctx context.Context, dcName string, dsNa
 }
 
 func (v *storagePolicyAPI) createZonalStoragePolicy(ctx context.Context) (string, error) {
-	var err error
 	failureDomains := v.infra.Spec.PlatformSpec.VSphere.FailureDomains
 
 	var aggregatedErrors []error
@@ -138,7 +149,19 @@ func (v *storagePolicyAPI) createZonalStoragePolicy(ctx context.Context) (string
 	for _, failureDomain := range failureDomains {
 		dataCenter := failureDomain.Topology.Datacenter
 		dataStore := failureDomain.Topology.Datastore
-		err := v.attachTags(ctx, dataCenter, dataStore)
+
+		// Resolve the correct connection for this failure domain's vCenter
+		conn := v.vcenterApiConnection
+		if v.connectionManager != nil && failureDomain.Server != "" {
+			if fdConn, ok := v.connectionManager.GetConnection(failureDomain.Server); ok {
+				conn = fdConn
+			} else {
+				aggregatedErrors = append(aggregatedErrors, fmt.Errorf("no connection for vCenter %s (failure domain %s)", failureDomain.Server, failureDomain.Name))
+				continue
+			}
+		}
+
+		err := v.attachTagsOnConnection(ctx, conn, dataCenter, dataStore)
 		if err != nil {
 			aggregatedErrors = append(aggregatedErrors, err)
 		}
@@ -148,12 +171,44 @@ func (v *storagePolicyAPI) createZonalStoragePolicy(ctx context.Context) (string
 		return v.policyName, errors.NewAggregate(aggregatedErrors)
 	}
 
-	// If we already created storage policy, we should return it
+	// Ensure storage profile exists on every vCenter
+	if v.connectionManager != nil && v.connectionManager.Len() > 1 {
+		for _, host := range v.connectionManager.Hosts() {
+			if v.policyCreatedPerVC[host] {
+				continue
+			}
+			conn, ok := v.connectionManager.GetConnection(host)
+			if !ok {
+				continue
+			}
+			found, err := v.checkForExistingPolicyOnConnection(ctx, conn)
+			if err != nil {
+				aggregatedErrors = append(aggregatedErrors, fmt.Errorf("error checking policy on vCenter %s: %v", host, err))
+				continue
+			}
+			if found {
+				v.policyCreatedPerVC[host] = true
+				continue
+			}
+			err = v.createStorageProfileOnConnection(ctx, conn)
+			if err != nil {
+				aggregatedErrors = append(aggregatedErrors, fmt.Errorf("error creating profile on vCenter %s: %v", host, err))
+			} else {
+				v.policyCreatedPerVC[host] = true
+			}
+		}
+		if len(aggregatedErrors) > 0 {
+			return v.policyName, errors.NewAggregate(aggregatedErrors)
+		}
+		return v.policyName, nil
+	}
+
+	// Single vCenter path (backward compatible)
 	if v.policyCreated {
 		return v.policyName, nil
 	}
 
-	err = v.createStorageProfile(ctx)
+	err := v.createStorageProfile(ctx)
 	if err != nil {
 		return v.policyName, fmt.Errorf("error create storage policy profile %s: %v", v.policyName, err)
 	}
@@ -179,6 +234,233 @@ func (v *storagePolicyAPI) attachTags(ctx context.Context, dcName, dsName string
 	return nil
 }
 
+// attachTagsOnConnection attaches tags to a datastore using a specific vCenter connection.
+func (v *storagePolicyAPI) attachTagsOnConnection(ctx context.Context, conn *vclib.VSphereConnection, dcName, dsName string) error {
+	ds, err := v.getDatastoreOnConnection(ctx, conn, dcName, dsName)
+	if err != nil {
+		return fmt.Errorf("unable to fetch datastore %s: %v", dsName, err)
+	}
+
+	// skip creation of tags on a datastore if it already has been tagged.
+	policyExists := v.policyCreated
+	if v.connectionManager != nil {
+		policyExists = v.policyCreatedPerVC[conn.Hostname]
+	}
+	if policyExists && v.checkForTagOnDatastoreOnConnection(ctx, conn, ds) {
+		return nil
+	}
+
+	err = v.createOrUpdateTagOnConnection(ctx, conn, ds)
+	if err != nil {
+		return fmt.Errorf("error tagging datastore %s with %s: %v", dsName, v.tagName, err)
+	}
+	return nil
+}
+
+// getDatastoreOnConnection retrieves datastore properties using a specific vCenter connection.
+func (v *storagePolicyAPI) getDatastoreOnConnection(ctx context.Context, conn *vclib.VSphereConnection, dcName string, dsName string) (*mo.Datastore, error) {
+	vmClient := conn.Client
+	finder := find.NewFinder(vmClient.Client, false)
+
+	dc, err := finder.Datacenter(ctx, dcName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to access datacenter %s: %s", dcName, err)
+	}
+
+	finder.SetDatacenter(dc)
+	ds, err := finder.Datastore(ctx, dsName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to access datastore %s: %s", dsName, err)
+	}
+
+	var dsMo mo.Datastore
+	pc := property.DefaultCollector(vmClient.Client)
+	properties := []string{DatastoreInfoProperty, SummaryProperty}
+	err = pc.RetrieveOne(ctx, ds.Reference(), properties, &dsMo)
+	if err != nil {
+		return nil, fmt.Errorf("error getting properties of datastore %s: %v", dsName, err)
+	}
+	return &dsMo, nil
+}
+
+// checkForTagOnDatastoreOnConnection checks if a datastore has the cluster tag using a specific connection.
+func (v *storagePolicyAPI) checkForTagOnDatastoreOnConnection(ctx context.Context, conn *vclib.VSphereConnection, dsMo *mo.Datastore) bool {
+	tagManager := tags.NewManager(conn.RestClient)
+	attachedTags, err := tagManager.GetAttachedTagsOnObjects(ctx, []mo.Reference{dsMo.Reference()})
+
+	if err != nil {
+		klog.Errorf("error fetching tags: %v", err)
+		return false
+	}
+
+	for _, tagObject := range attachedTags {
+		tagObjectArray := tagObject.Tags
+		for _, tag := range tagObjectArray {
+			if tag.Name == v.tagName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// createOrUpdateTagOnConnection creates or updates the tag on a datastore using a specific connection.
+func (v *storagePolicyAPI) createOrUpdateTagOnConnection(ctx context.Context, conn *vclib.VSphereConnection, ds *mo.Datastore) error {
+	tagManager := tags.NewManager(conn.RestClient)
+
+	category, err := tagManager.GetCategory(ctx, v.categoryName)
+	if err != nil && !notFoundError(err) {
+		return fmt.Errorf("error finding category: %+v", err)
+	}
+
+	associatedTypes := appendPrefix(associatedTypesRaw)
+	if category == nil || category.ID == "" {
+		klog.Warningf("Unexpected missing category %s - creating it", v.categoryName)
+		category = &tags.Category{
+			Name:            v.categoryName,
+			Description:     "Added by openshift-install do not remove",
+			AssociableTypes: associatedTypes,
+			Cardinality:     "SINGLE",
+		}
+		v.apiTestInfo[create_category_api]++
+		catId, err := tagManager.CreateCategory(ctx, category)
+		if err != nil {
+			return fmt.Errorf("error creating category %s: %v", v.categoryName, err)
+		}
+		klog.V(2).Infof("Created category %s on vCenter %s", v.categoryName, conn.Hostname)
+		category.ID = catId
+	} else {
+		existingAssociatedTypes := category.AssociableTypes
+		associatedTypes = updateAssociatedTypes(existingAssociatedTypes)
+		category.AssociableTypes = associatedTypes
+		klog.V(4).Infof("Final categories are: %+v", associatedTypes)
+		v.apiTestInfo[update_category_api]++
+		err := tagManager.UpdateCategory(ctx, category)
+		if err != nil {
+			return fmt.Errorf("error updating category %s: %v", v.categoryName, err)
+		}
+		klog.V(2).Infof("Updated category %s with associated types on vCenter %s", v.categoryName, conn.Hostname)
+	}
+
+	tag, err := tagManager.GetTag(ctx, v.tagName)
+	if err != nil && !notFoundError(err) {
+		return fmt.Errorf("error finding tag %s: %v", v.tagName, err)
+	}
+	if tag == nil || tag.ID == "" {
+		klog.Warningf("Unexpected missing tag %s - creating it", v.tagName)
+		tag = &tags.Tag{
+			Name:        v.tagName,
+			Description: "Added by openshift-install do not remove",
+			CategoryID:  category.ID,
+		}
+		v.apiTestInfo[create_tag_api]++
+		tagID, err := tagManager.CreateTag(ctx, tag)
+		if err != nil {
+			return fmt.Errorf("error creating tag %s: %v", v.tagName, err)
+		}
+		klog.V(2).Infof("Created tag %s on vCenter %s", v.tagName, conn.Hostname)
+		tag.ID = tagID
+	} else if tag.CategoryID != category.ID {
+		tag = &tags.Tag{
+			Name:        v.tagName,
+			Description: "Added by openshift-install do not remove",
+			CategoryID:  category.ID,
+			ID:          tag.ID,
+		}
+		v.apiTestInfo[update_tag_api]++
+		err := tagManager.UpdateTag(ctx, tag)
+		if err != nil {
+			return fmt.Errorf("error updating tag %s: %v", v.tagName, err)
+		}
+		klog.V(2).Infof("Updated tag %s on vCenter %s", v.tagName, conn.Hostname)
+	}
+
+	dsName := ds.Summary.Name
+	v.apiTestInfo[attach_tag_api]++
+	err = tagManager.AttachTag(ctx, tag.ID, ds)
+	if err != nil {
+		klog.Errorf("error attaching tag %s to datastore %s on vCenter %s: %v", v.tagName, dsName, conn.Hostname, err)
+		return err
+	}
+	return nil
+}
+
+// checkForExistingPolicyOnConnection checks for an existing SPBM policy on a specific vCenter.
+func (v *storagePolicyAPI) checkForExistingPolicyOnConnection(ctx context.Context, conn *vclib.VSphereConnection) (bool, error) {
+	rtype := types.PbmProfileResourceType{
+		ResourceType: string(types.PbmProfileResourceTypeEnumSTORAGE),
+	}
+
+	category := types.PbmProfileCategoryEnumREQUIREMENT
+
+	pbmClient, err := pbm.NewClient(ctx, conn.Client.Client)
+	if err != nil {
+		return false, fmt.Errorf("error creating pbm client on vCenter %s: %v", conn.Hostname, err)
+	}
+
+	ids, err := pbmClient.QueryProfile(ctx, rtype, string(category))
+	if err != nil {
+		return false, fmt.Errorf("error querying profiles on vCenter %s: %v", conn.Hostname, err)
+	}
+
+	profiles, err := pbmClient.RetrieveContent(ctx, ids)
+	if err != nil {
+		return false, fmt.Errorf("error fetching policy profiles on vCenter %s: %v", conn.Hostname, err)
+	}
+
+	for _, p := range profiles {
+		if p.GetPbmProfile().Name == v.policyName {
+			klog.V(2).Infof("Found existing profile with same name: %s on vCenter %s", p.GetPbmProfile().Name, conn.Hostname)
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// createStorageProfileOnConnection creates an SPBM profile on a specific vCenter.
+func (v *storagePolicyAPI) createStorageProfileOnConnection(ctx context.Context, conn *vclib.VSphereConnection) error {
+	pbmClient, err := pbm.NewClient(ctx, conn.Client.Client)
+	if err != nil {
+		return fmt.Errorf("error creating pbm client on vCenter %s: %v", conn.Hostname, err)
+	}
+
+	var policySpec types.PbmCapabilityProfileCreateSpec
+	policySpec.Name = v.policyName
+	policySpec.Category = "REQUIREMENT"
+	policySpec.ResourceType.ResourceType = string(types.PbmProfileResourceTypeEnumSTORAGE)
+
+	policyID := fmt.Sprintf("com.vmware.storage.tag.%s.property", v.categoryName)
+	instance := types.PbmCapabilityInstance{
+		Id: types.PbmCapabilityMetadataUniqueId{
+			Namespace: "http://www.vmware.com/storage/tag",
+			Id:        v.categoryName,
+		},
+		Constraint: []types.PbmCapabilityConstraintInstance{{
+			PropertyInstance: []types.PbmCapabilityPropertyInstance{{
+				Id: policyID,
+				Value: types.PbmCapabilityDiscreteSet{
+					Values: []vim.AnyType{v.tagName},
+				},
+			}},
+		}},
+	}
+
+	policySpec.Constraints = &types.PbmCapabilitySubProfileConstraints{
+		SubProfiles: []types.PbmCapabilitySubProfile{{
+			Name:       "Tag based placement",
+			Capability: []types.PbmCapabilityInstance{instance},
+		}},
+	}
+
+	v.apiTestInfo[create_profile_api]++
+	pid, err := pbmClient.CreateProfile(ctx, policySpec)
+	if err != nil {
+		return fmt.Errorf("error creating profile on vCenter %s: %v", conn.Hostname, err)
+	}
+	klog.V(2).Infof("Successfully created profile %s on vCenter %s", pid.UniqueId, conn.Hostname)
+	return nil
+}
+
 func (v *storagePolicyAPI) createStoragePolicy(ctx context.Context) (string, error) {
 	found, err := v.checkForExistingPolicy(ctx)
 	if err != nil {
@@ -187,6 +469,18 @@ func (v *storagePolicyAPI) createStoragePolicy(ctx context.Context) (string, err
 
 	if found {
 		v.policyCreated = true
+	}
+
+	// Run orphan cleanup regardless of FD count — this handles the
+	// transition from zonal (2+ FDs) to non-zonal (0 FDs) as well.
+	if found {
+		orphans, err := v.findOrphanedTags(ctx)
+		if err != nil {
+			klog.Warningf("Error detecting orphaned tags: %v", err)
+		} else if len(orphans) > 0 {
+			klog.V(2).Infof("Found %d orphaned tags, running cleanup", len(orphans))
+			v.detachOrphanTags(ctx, orphans)
+		}
 	}
 
 	vSphereInfraConfig := v.infra.Spec.PlatformSpec.VSphere
@@ -465,4 +759,204 @@ func appendPrefix(associableTypes []string) []string {
 	// different associated type.
 	sort.Strings(appendedTypes)
 	return appendedTypes
+}
+
+// orphanedDatastore identifies a datastore that has the cluster tag but is not
+// in the current failure domain list.
+type orphanedDatastore struct {
+	// VCenter is the hostname of the vCenter (always workspace vCenter in Phase 3A).
+	VCenter string
+	// Datacenter is the datacenter containing this datastore.
+	Datacenter string
+	// Datastore is the datastore name.
+	Datastore string
+	// Reference is the managed object reference for this datastore.
+	Reference vim.ManagedObjectReference
+	// HasBoundPVs indicates whether CNS volumes backed by this datastore
+	// have matching PVs in the cluster.
+	HasBoundPVs bool
+}
+
+// findOrphanedTags queries vCenter for all datastores tagged with the cluster tag,
+// then compares against the current failure domain list. Any tagged datastore not in
+// the current failure domains is an orphan. The comparison key is the full
+// (datacenter, datastore) tuple to prevent false matches when datastore names
+// collide across datacenters.
+func (v *storagePolicyAPI) findOrphanedTags(ctx context.Context) ([]orphanedDatastore, error) {
+	conn := v.vcenterApiConnection
+	if conn == nil || conn.RestClient == nil {
+		return nil, fmt.Errorf("no vCenter connection available for orphan detection")
+	}
+
+	tagManager := tags.NewManager(conn.RestClient)
+
+	// Get the tag by name
+	tag, err := tagManager.GetTag(ctx, v.tagName)
+	if err != nil {
+		if notFoundError(err) {
+			klog.V(4).Infof("Tag %s not found, no orphans possible", v.tagName)
+			return nil, nil
+		}
+		return nil, fmt.Errorf("error finding tag %s: %v", v.tagName, err)
+	}
+
+	if tag == nil || tag.ID == "" {
+		return nil, nil
+	}
+
+	// Get all objects with this tag
+	attachedObjects, err := tagManager.GetAttachedObjectsOnTags(ctx, []string{tag.ID})
+	if err != nil {
+		return nil, fmt.Errorf("error getting attached objects for tag %s: %v", v.tagName, err)
+	}
+
+	// Build set of current failure domain (datacenter, datastore) tuples
+	currentFDs := sets.NewString()
+	if v.infra.Spec.PlatformSpec.VSphere != nil {
+		for _, fd := range v.infra.Spec.PlatformSpec.VSphere.FailureDomains {
+			key := fd.Topology.Datacenter + "/" + fd.Topology.Datastore
+			currentFDs.Insert(key)
+		}
+	}
+
+	// Also include the workspace default datastore if no failure domains
+	if currentFDs.Len() == 0 && conn.Config != nil {
+		workspaceDC := conn.Config.Workspace.Datacenter
+		workspaceDS := conn.Config.Workspace.DefaultDatastore
+		if workspaceDC != "" && workspaceDS != "" {
+			currentFDs.Insert(workspaceDC + "/" + workspaceDS)
+		}
+	}
+
+	var orphans []orphanedDatastore
+
+	for _, tagResult := range attachedObjects {
+		for _, objRef := range tagResult.ObjectIDs {
+			// Only interested in Datastore objects
+			if objRef.Reference().Type != "Datastore" {
+				continue
+			}
+
+			// Resolve the datastore's datacenter and name
+			dcName, dsName, err := v.resolveDatastoreIdentity(ctx, conn, objRef.Reference())
+			if err != nil {
+				klog.Warningf("Could not resolve identity for tagged object %s: %v", objRef.Reference(), err)
+				continue
+			}
+
+			key := dcName + "/" + dsName
+			if !currentFDs.Has(key) {
+				orphans = append(orphans, orphanedDatastore{
+					VCenter:    conn.Hostname,
+					Datacenter: dcName,
+					Datastore:  dsName,
+					Reference:  objRef.Reference(),
+				})
+			}
+		}
+	}
+
+	return orphans, nil
+}
+
+// resolveDatastoreIdentity determines the datacenter and name for a datastore by its MOR.
+func (v *storagePolicyAPI) resolveDatastoreIdentity(ctx context.Context, conn *vclib.VSphereConnection, ref vim.ManagedObjectReference) (datacenterName, datastoreName string, err error) {
+	pc := property.DefaultCollector(conn.Client.Client)
+
+	var dsMo mo.Datastore
+	err = pc.RetrieveOne(ctx, ref, []string{SummaryProperty}, &dsMo)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to retrieve datastore properties: %v", err)
+	}
+	datastoreName = dsMo.Summary.Name
+
+	// Find which datacenter contains this datastore by searching all datacenters
+	finder := find.NewFinder(conn.Client.Client, false)
+	datacenters, err := finder.DatacenterList(ctx, "*")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to list datacenters: %v", err)
+	}
+
+	for _, dc := range datacenters {
+		dcFinder := find.NewFinder(conn.Client.Client, false)
+		dcFinder.SetDatacenter(dc)
+		dsList, err := dcFinder.DatastoreList(ctx, "*")
+		if err != nil {
+			continue
+		}
+		for _, ds := range dsList {
+			if ds.Reference() == ref {
+				return dc.Name(), datastoreName, nil
+			}
+		}
+	}
+
+	return "", datastoreName, fmt.Errorf("could not find datacenter for datastore %s", datastoreName)
+}
+
+// detachOrphanTags removes tags from orphaned datastores that don't have bound PVs.
+// For datastores with bound PVs, it skips the detach and logs a warning.
+// Returns the list of orphans that could not be cleaned up (PV-blocked).
+func (v *storagePolicyAPI) detachOrphanTags(ctx context.Context, orphans []orphanedDatastore) []orphanedDatastore {
+	if len(orphans) == 0 {
+		return nil
+	}
+
+	conn := v.vcenterApiConnection
+	if conn == nil || conn.RestClient == nil {
+		klog.Errorf("No vCenter connection available for orphan tag detach")
+		return orphans
+	}
+
+	// Check for force-cleanup annotation on ClusterCSIDriver
+	forceCleanup := false
+	if v.infra != nil {
+		// The annotation is checked on the Infrastructure resource for simplicity
+		if v.infra.Annotations != nil {
+			if val, ok := v.infra.Annotations["csi.vsphere.vmware.com/force-orphan-cleanup"]; ok && val == "true" {
+				klog.V(2).Infof("Force orphan cleanup annotation found, skipping PV safety check")
+				forceCleanup = true
+			}
+		}
+	}
+
+	tagManager := tags.NewManager(conn.RestClient)
+
+	tag, err := tagManager.GetTag(ctx, v.tagName)
+	if err != nil || tag == nil || tag.ID == "" {
+		klog.Errorf("Could not find tag %s for orphan detach: %v", v.tagName, err)
+		return orphans
+	}
+
+	utils.OrphanTagsDetectedTotal.Add(float64(len(orphans)))
+
+	var pvBlocked []orphanedDatastore
+
+	for i := range orphans {
+		orphan := &orphans[i]
+
+		if orphan.HasBoundPVs && !forceCleanup {
+			klog.Warningf("Skipping tag detach from datastore %s in datacenter %s: has bound PVs",
+				orphan.Datastore, orphan.Datacenter)
+			utils.TagOperationsTotal.WithLabelValues("skip", "pv_blocked").Inc()
+			pvBlocked = append(pvBlocked, *orphan)
+			continue
+		}
+
+		ref := orphan.Reference
+		err := tagManager.DetachTag(ctx, tag.ID, ref)
+		if err != nil {
+			klog.Errorf("Failed to detach tag %s from datastore %s in datacenter %s: %v",
+				v.tagName, orphan.Datastore, orphan.Datacenter, err)
+			utils.TagOperationsTotal.WithLabelValues("detach", "error").Inc()
+			pvBlocked = append(pvBlocked, *orphan)
+			continue
+		}
+
+		klog.V(2).Infof("Successfully detached tag %s from orphaned datastore %s in datacenter %s",
+			v.tagName, orphan.Datastore, orphan.Datacenter)
+		utils.TagOperationsTotal.WithLabelValues("detach", "success").Inc()
+	}
+
+	return pvBlocked
 }

--- a/pkg/operator/utils/metric.go
+++ b/pkg/operator/utils/metric.go
@@ -48,10 +48,31 @@ var (
 		},
 		[]string{domainScope},
 	)
+
+	// TagOperationsTotal counts tag attach/detach/skip operations.
+	TagOperationsTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Name:           "vsphere_csi_tag_operations_total",
+			Help:           "Total number of vSphere CSI tag operations",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"operation", "result"},
+	)
+
+	// OrphanTagsDetectedTotal counts orphaned tags detected.
+	OrphanTagsDetectedTotal = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Name:           "vsphere_csi_orphan_tags_detected_total",
+			Help:           "Total number of orphaned tags detected",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
 )
 
 func init() {
 	legacyregistry.MustRegister(InstallErrorMetric)
 	legacyregistry.MustRegister(TopologyTagsMetric)
 	legacyregistry.MustRegister(InfrastructureFailureDomains)
+	legacyregistry.MustRegister(TagOperationsTotal)
+	legacyregistry.MustRegister(OrphanTagsDetectedTotal)
 }

--- a/pkg/operator/utils/topology.go
+++ b/pkg/operator/utils/topology.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"fmt"
 	"strings"
 
 	cfgv1 "github.com/openshift/api/config/v1"
@@ -46,19 +45,23 @@ func GetTopologyCategories(clusterCSIDriver *opv1.ClusterCSIDriver, infra *cfgv1
 }
 
 func GetDatacenters(config *vsphere.VSphereConfig) ([]string, error) {
-	datacenters := []string{config.Workspace.Datacenter}
+	var allDatacenters []string
+	seen := sets.NewString()
 
-	virtualCenterIPs := sets.StringKeySet(config.VirtualCenter)
-
-	if len(virtualCenterIPs) != 1 {
-		return nil, fmt.Errorf("cloud config must define a single VirtualCenter")
+	for _, vcConfig := range config.VirtualCenter {
+		for _, dc := range strings.Split(vcConfig.Datacenters, ",") {
+			dc = strings.TrimSpace(dc)
+			if dc != "" && !seen.Has(dc) {
+				allDatacenters = append(allDatacenters, dc)
+				seen.Insert(dc)
+			}
+		}
 	}
 
-	virtualCenterIP := virtualCenterIPs.List()[0]
-	if virtualCenterConfig, ok := config.VirtualCenter[virtualCenterIP]; ok {
-		datacenters = strings.Split(virtualCenterConfig.Datacenters, ",")
+	if len(allDatacenters) == 0 {
+		allDatacenters = []string{config.Workspace.Datacenter}
 	}
-	return datacenters, nil
+	return allDatacenters, nil
 }
 
 func UpdateMetrics(infra *cfgv1.Infrastructure, clusterCSIDriver *opv1.ClusterCSIDriver) {

--- a/pkg/operator/utils/topology_test.go
+++ b/pkg/operator/utils/topology_test.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -8,6 +10,7 @@ import (
 	opv1 "github.com/openshift/api/operator/v1"
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/component-base/metrics/testutil"
+	"k8s.io/legacy-cloud-providers/vsphere"
 )
 
 func TestUpdateMetrics(t *testing.T) {
@@ -371,7 +374,8 @@ vsphere_topology_tags{source="infrastructure"} 0
 `,
 		},
 	}
-	for _, test := range tests {
+	for i := range tests {
+		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {
 			// Reset metrics from previous tests. Note: the tests can't run in parallel!
 			legacyregistry.Reset()
@@ -379,6 +383,93 @@ vsphere_topology_tags{source="infrastructure"} 0
 			UpdateMetrics(test.infra, test.clusterCSIDriver)
 			if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(test.expectedMetrics), "vsphere_topology_tags", "vsphere_infrastructure_failure_domains"); err != nil {
 				t.Errorf("Unexpected metric: %s", err)
+			}
+		})
+	}
+}
+
+func makeVSphereConfig(vcs map[string]string, workspaceDC string) *vsphere.VSphereConfig {
+	cfg := &vsphere.VSphereConfig{
+		VirtualCenter: make(map[string]*vsphere.VirtualCenterConfig),
+	}
+	cfg.Workspace.Datacenter = workspaceDC
+	for host, dcs := range vcs {
+		cfg.VirtualCenter[host] = &vsphere.VirtualCenterConfig{Datacenters: dcs}
+	}
+	return cfg
+}
+
+func TestGetDatacenters(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   *vsphere.VSphereConfig
+		expected []string
+		wantErr  bool
+	}{
+		{
+			name:     "single VirtualCenter with one datacenter",
+			config:   makeVSphereConfig(map[string]string{"vcenter1.example.com": "dc1"}, "dc1"),
+			expected: []string{"dc1"},
+		},
+		{
+			name:     "single VirtualCenter with multiple datacenters",
+			config:   makeVSphereConfig(map[string]string{"vcenter1.example.com": "dc1,dc2,dc3"}, "dc1"),
+			expected: []string{"dc1", "dc2", "dc3"},
+		},
+		{
+			name: "multiple VirtualCenters with different datacenters",
+			config: makeVSphereConfig(map[string]string{
+				"vcenter1.example.com": "dc1,dc2",
+				"vcenter2.example.com": "dc3",
+			}, "dc1"),
+			expected: []string{"dc1", "dc2", "dc3"},
+		},
+		{
+			name: "multiple VirtualCenters with overlapping datacenters",
+			config: makeVSphereConfig(map[string]string{
+				"vcenter1.example.com": "dc1,dc2",
+				"vcenter2.example.com": "dc2,dc3",
+			}, "dc1"),
+			expected: []string{"dc1", "dc2", "dc3"},
+		},
+		{
+			name:     "no VirtualCenters falls back to workspace datacenter",
+			config:   makeVSphereConfig(map[string]string{}, "default-dc"),
+			expected: []string{"default-dc"},
+		},
+		{
+			name:     "VirtualCenter with empty datacenters falls back to workspace",
+			config:   makeVSphereConfig(map[string]string{"vcenter1.example.com": ""}, "default-dc"),
+			expected: []string{"default-dc"},
+		},
+		{
+			name:     "VirtualCenter with whitespace in datacenters",
+			config:   makeVSphereConfig(map[string]string{"vcenter1.example.com": " dc1 , dc2 "}, "dc1"),
+			expected: []string{"dc1", "dc2"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := GetDatacenters(test.config)
+			if test.wantErr {
+				if err == nil {
+					t.Error("expected error, got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Sort both for deterministic comparison since map iteration is non-deterministic
+			sort.Strings(got)
+			sortedExpected := make([]string, len(test.expected))
+			copy(sortedExpected, test.expected)
+			sort.Strings(sortedExpected)
+
+			if !reflect.DeepEqual(got, sortedExpected) {
+				t.Errorf("expected %v, got %v", sortedExpected, got)
 			}
 		})
 	}

--- a/pkg/operator/vclib/connection_manager.go
+++ b/pkg/operator/vclib/connection_manager.go
@@ -1,0 +1,203 @@
+package vclib
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"k8s.io/klog/v2"
+)
+
+// ConnectionErrorCategory classifies the type of connection failure.
+type ConnectionErrorCategory int
+
+const (
+	// CredentialsMissing indicates the secret does not contain credentials for this vCenter.
+	CredentialsMissing ConnectionErrorCategory = iota
+	// NetworkUnreachable indicates TCP connection to vCenter failed.
+	NetworkUnreachable
+	// AuthenticationFailed indicates credentials were rejected by vCenter.
+	AuthenticationFailed
+	// SessionError indicates the REST session could not be established.
+	SessionError
+)
+
+// ConnectionError is a typed error from ConnectAll, carrying the hostname and failure category.
+type ConnectionError struct {
+	Host     string
+	Category ConnectionErrorCategory
+	Err      error
+}
+
+func (e *ConnectionError) Error() string {
+	return fmt.Sprintf("connection to vCenter %s failed: %v", e.Host, e.Err)
+}
+
+func (e *ConnectionError) Unwrap() error {
+	return e.Err
+}
+
+// VSphereConnectionManager manages connections to multiple vCenters.
+type VSphereConnectionManager struct {
+	connections map[string]*VSphereConnection // keyed by vCenter hostname
+	primary     string                        // hostname of the workspace/primary vCenter
+	mu          sync.RWMutex
+}
+
+// NewVSphereConnectionManager creates a new empty connection manager.
+func NewVSphereConnectionManager() *VSphereConnectionManager {
+	return &VSphereConnectionManager{
+		connections: make(map[string]*VSphereConnection),
+	}
+}
+
+// GetConnection returns the connection for the given vCenter hostname, if it exists.
+func (m *VSphereConnectionManager) GetConnection(vcenterHost string) (*VSphereConnection, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	conn, ok := m.connections[vcenterHost]
+	return conn, ok
+}
+
+// GetPrimary returns the connection for the primary (workspace) vCenter.
+// Returns nil if no primary is set or the primary is not in the connection map.
+func (m *VSphereConnectionManager) GetPrimary() *VSphereConnection {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.primary == "" {
+		return nil
+	}
+	return m.connections[m.primary]
+}
+
+// SetPrimary sets the hostname of the primary (workspace) vCenter.
+func (m *VSphereConnectionManager) SetPrimary(host string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.primary = host
+}
+
+// PrimaryHost returns the hostname of the primary vCenter.
+func (m *VSphereConnectionManager) PrimaryHost() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.primary
+}
+
+// AddConnection adds a connection for the given vCenter hostname.
+func (m *VSphereConnectionManager) AddConnection(host string, conn *VSphereConnection) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.connections[host] = conn
+}
+
+// ConnectAll connects to all registered vCenters. Returns a slice of ConnectionError for any
+// that failed. Connections that succeed are usable even if others fail.
+func (m *VSphereConnectionManager) ConnectAll(ctx context.Context) []*ConnectionError {
+	m.mu.RLock()
+	hosts := make([]string, 0, len(m.connections))
+	for h := range m.connections {
+		hosts = append(hosts, h)
+	}
+	m.mu.RUnlock()
+
+	var (
+		errs []*ConnectionError
+		mu   sync.Mutex
+		wg   sync.WaitGroup
+	)
+
+	for _, host := range hosts {
+		wg.Add(1)
+		go func(h string) {
+			defer wg.Done()
+			m.mu.RLock()
+			conn := m.connections[h]
+			m.mu.RUnlock()
+
+			if conn == nil {
+				mu.Lock()
+				errs = append(errs, &ConnectionError{
+					Host:     h,
+					Category: CredentialsMissing,
+					Err:      fmt.Errorf("no connection object for host %s", h),
+				})
+				mu.Unlock()
+				return
+			}
+
+			err := conn.Connect(ctx)
+			if err != nil {
+				category := categorizeConnectionError(err)
+				klog.Errorf("Failed to connect to vCenter %s: %v", h, err)
+				mu.Lock()
+				errs = append(errs, &ConnectionError{
+					Host:     h,
+					Category: category,
+					Err:      err,
+				})
+				mu.Unlock()
+			}
+		}(host)
+	}
+
+	wg.Wait()
+	return errs
+}
+
+// LogoutAll logs out from all connected vCenters.
+func (m *VSphereConnectionManager) LogoutAll(ctx context.Context) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for host, conn := range m.connections {
+		if conn != nil && conn.Client != nil {
+			if err := conn.Logout(ctx); err != nil {
+				klog.Errorf("Failed to logout from vCenter %s: %v", host, err)
+			}
+		}
+	}
+}
+
+// Hosts returns a sorted list of all vCenter hostnames in the manager.
+func (m *VSphereConnectionManager) Hosts() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	hosts := make([]string, 0, len(m.connections))
+	for h := range m.connections {
+		hosts = append(hosts, h)
+	}
+	sort.Strings(hosts)
+	return hosts
+}
+
+// Len returns the number of connections in the manager.
+func (m *VSphereConnectionManager) Len() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.connections)
+}
+
+// categorizeConnectionError attempts to classify a connection error.
+// This is best-effort; errors that don't match known patterns are categorized as NetworkUnreachable.
+func categorizeConnectionError(err error) ConnectionErrorCategory {
+	if err == nil {
+		return NetworkUnreachable
+	}
+	errStr := err.Error()
+	// Check for authentication failures
+	if strings.Contains(errStr, "incorrect user name or password") ||
+		strings.Contains(errStr, "Cannot complete login") ||
+		strings.Contains(errStr, "InvalidLogin") {
+		return AuthenticationFailed
+	}
+	// Check for REST session errors
+	if strings.Contains(errStr, "RESTful services") ||
+		strings.Contains(errStr, "rest session") {
+		return SessionError
+	}
+	return NetworkUnreachable
+}

--- a/pkg/operator/vclib/connection_manager_test.go
+++ b/pkg/operator/vclib/connection_manager_test.go
@@ -1,0 +1,200 @@
+package vclib
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestNewVSphereConnectionManager(t *testing.T) {
+	mgr := NewVSphereConnectionManager()
+	if mgr == nil {
+		t.Fatal("expected non-nil manager")
+	}
+	if mgr.Len() != 0 {
+		t.Errorf("expected 0 connections, got %d", mgr.Len())
+	}
+	if mgr.GetPrimary() != nil {
+		t.Error("expected nil primary")
+	}
+}
+
+func TestAddAndGetConnection(t *testing.T) {
+	mgr := NewVSphereConnectionManager()
+	conn := &VSphereConnection{Hostname: "vcenter1.example.com"}
+
+	mgr.AddConnection("vcenter1.example.com", conn)
+
+	got, ok := mgr.GetConnection("vcenter1.example.com")
+	if !ok {
+		t.Fatal("expected connection to exist")
+	}
+	if got != conn {
+		t.Error("returned connection does not match added connection")
+	}
+
+	_, ok = mgr.GetConnection("vcenter2.example.com")
+	if ok {
+		t.Error("expected connection to not exist")
+	}
+}
+
+func TestSetAndGetPrimary(t *testing.T) {
+	mgr := NewVSphereConnectionManager()
+	conn1 := &VSphereConnection{Hostname: "vcenter1.example.com"}
+	conn2 := &VSphereConnection{Hostname: "vcenter2.example.com"}
+
+	mgr.AddConnection("vcenter1.example.com", conn1)
+	mgr.AddConnection("vcenter2.example.com", conn2)
+	mgr.SetPrimary("vcenter1.example.com")
+
+	primary := mgr.GetPrimary()
+	if primary != conn1 {
+		t.Error("expected primary to be vcenter1")
+	}
+	if mgr.PrimaryHost() != "vcenter1.example.com" {
+		t.Errorf("expected primary host vcenter1.example.com, got %s", mgr.PrimaryHost())
+	}
+}
+
+func TestGetPrimaryNotSet(t *testing.T) {
+	mgr := NewVSphereConnectionManager()
+	conn := &VSphereConnection{Hostname: "vcenter1.example.com"}
+	mgr.AddConnection("vcenter1.example.com", conn)
+
+	if mgr.GetPrimary() != nil {
+		t.Error("expected nil primary when not set")
+	}
+}
+
+func TestGetPrimaryNotInConnections(t *testing.T) {
+	mgr := NewVSphereConnectionManager()
+	conn := &VSphereConnection{Hostname: "vcenter1.example.com"}
+	mgr.AddConnection("vcenter1.example.com", conn)
+	mgr.SetPrimary("vcenter-missing.example.com")
+
+	if mgr.GetPrimary() != nil {
+		t.Error("expected nil when primary is not in connections map")
+	}
+}
+
+func TestHostsSorted(t *testing.T) {
+	mgr := NewVSphereConnectionManager()
+	mgr.AddConnection("zcenter.example.com", &VSphereConnection{Hostname: "zcenter.example.com"})
+	mgr.AddConnection("acenter.example.com", &VSphereConnection{Hostname: "acenter.example.com"})
+	mgr.AddConnection("mcenter.example.com", &VSphereConnection{Hostname: "mcenter.example.com"})
+
+	hosts := mgr.Hosts()
+	if len(hosts) != 3 {
+		t.Fatalf("expected 3 hosts, got %d", len(hosts))
+	}
+	expected := []string{"acenter.example.com", "mcenter.example.com", "zcenter.example.com"}
+	for i, h := range hosts {
+		if h != expected[i] {
+			t.Errorf("host %d: expected %s, got %s", i, expected[i], h)
+		}
+	}
+}
+
+func TestLen(t *testing.T) {
+	mgr := NewVSphereConnectionManager()
+	if mgr.Len() != 0 {
+		t.Errorf("expected 0, got %d", mgr.Len())
+	}
+	mgr.AddConnection("a", &VSphereConnection{})
+	if mgr.Len() != 1 {
+		t.Errorf("expected 1, got %d", mgr.Len())
+	}
+	mgr.AddConnection("b", &VSphereConnection{})
+	if mgr.Len() != 2 {
+		t.Errorf("expected 2, got %d", mgr.Len())
+	}
+}
+
+func TestCategorizeConnectionError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected ConnectionErrorCategory
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: NetworkUnreachable,
+		},
+		{
+			name:     "authentication failure - incorrect password",
+			err:      fmt.Errorf("incorrect user name or password"),
+			expected: AuthenticationFailed,
+		},
+		{
+			name:     "authentication failure - cannot complete login",
+			err:      fmt.Errorf("Cannot complete login due to an incorrect user name or password"),
+			expected: AuthenticationFailed,
+		},
+		{
+			name:     "authentication failure - InvalidLogin",
+			err:      fmt.Errorf("ServerFaultCode: InvalidLogin"),
+			expected: AuthenticationFailed,
+		},
+		{
+			name:     "REST session error",
+			err:      fmt.Errorf("error logging into vcenter RESTful services: 401"),
+			expected: SessionError,
+		},
+		{
+			name:     "network error",
+			err:      fmt.Errorf("dial tcp: connection refused"),
+			expected: NetworkUnreachable,
+		},
+		{
+			name:     "unknown error defaults to network",
+			err:      fmt.Errorf("something unexpected happened"),
+			expected: NetworkUnreachable,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := categorizeConnectionError(tc.err)
+			if got != tc.expected {
+				t.Errorf("expected category %d, got %d", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestConnectionErrorUnwrap(t *testing.T) {
+	inner := fmt.Errorf("inner error")
+	ce := &ConnectionError{
+		Host:     "test-host",
+		Category: AuthenticationFailed,
+		Err:      inner,
+	}
+
+	if ce.Unwrap() != inner {
+		t.Error("Unwrap should return inner error")
+	}
+	if ce.Error() == "" {
+		t.Error("Error() should return non-empty string")
+	}
+}
+
+// TestLogoutAllNilClients verifies LogoutAll does not panic when connections have nil clients.
+func TestLogoutAllNilClients(t *testing.T) {
+	mgr := NewVSphereConnectionManager()
+	mgr.AddConnection("a", &VSphereConnection{Hostname: "a"})
+	mgr.AddConnection("b", &VSphereConnection{Hostname: "b"})
+
+	// Should not panic
+	mgr.LogoutAll(context.Background())
+}
+
+// TestConnectAllNoConnections verifies ConnectAll with empty manager returns no errors.
+func TestConnectAllNoConnections(t *testing.T) {
+	mgr := NewVSphereConnectionManager()
+	errs := mgr.ConnectAll(context.Background())
+	if len(errs) != 0 {
+		t.Errorf("expected 0 errors, got %d", len(errs))
+	}
+}

--- a/pkg/operator/vspherecontroller/driver_starter.go
+++ b/pkg/operator/vspherecontroller/driver_starter.go
@@ -218,8 +218,18 @@ func WithVSphereCredentials(
 		// So we need to figure those keys out
 		var usernameKey, passwordKey string
 
-		if len(secret.Data) > 2 {
+		// When multiple vCenters are configured, the secret will contain more than 2 keys
+		// (one username+password pair per vCenter). The CSI driver env vars can only hold
+		// one set of credentials (for the primary/workspace vCenter). Secondary vCenter
+		// credentials are read from the config file by the CSI driver itself.
+		vcenterCount := 0
+		if vSphereInfraConfig := infra.Spec.PlatformSpec.VSphere; vSphereInfraConfig != nil {
+			vcenterCount = len(vSphereInfraConfig.VCenters)
+		}
+		if len(secret.Data) > 2 && vcenterCount <= 1 {
 			klog.Warningf("CSI driver can only connect to one vcenter, more than 1 set of credentials found for CSI driver")
+		} else if len(secret.Data) > 2 && vcenterCount > 1 {
+			klog.V(2).Infof("Multiple vCenters configured (%d), injecting credentials for primary vCenter %s", vcenterCount, vCenterName)
 		}
 
 		usernameKey = vCenterName + ".username"

--- a/pkg/operator/vspherecontroller/driver_starter_test.go
+++ b/pkg/operator/vspherecontroller/driver_starter_test.go
@@ -3,11 +3,13 @@ package vspherecontroller
 import (
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	ocpv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/testlib"
+	"github.com/openshift/vmware-vsphere-csi-driver-operator/pkg/operator/utils"
 )
 
 func TestGetvCenterName(t *testing.T) {
@@ -64,3 +66,166 @@ func TestGetvCenterName(t *testing.T) {
 		})
 	}
 }
+
+// TestTopologyHookTransitions verifies that the topology hook correctly handles
+// transitions between topology-enabled and topology-disabled states.
+// The hook only appends topology args when categories exist — since library-go's
+// DeploymentController reads from the manifest base each sync, this means
+// topology args naturally disappear when categories are empty.
+func TestTopologyHookTransitions(t *testing.T) {
+	tests := []struct {
+		name                string
+		failureDomainCount  int
+		expectTopologyArgs  bool
+	}{
+		{
+			name:               "2+ failure domains enables topology",
+			failureDomainCount: 2,
+			expectTopologyArgs: true,
+		},
+		{
+			name:               "1 failure domain disables topology",
+			failureDomainCount: 1,
+			expectTopologyArgs: false,
+		},
+		{
+			name:               "0 failure domains disables topology",
+			failureDomainCount: 0,
+			expectTopologyArgs: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			infraObj := testlib.GetInfraObject()
+
+			// Set up failure domains
+			if infraObj.Spec.PlatformSpec.VSphere == nil {
+				infraObj.Spec.PlatformSpec.VSphere = &ocpv1.VSpherePlatformSpec{}
+			}
+			infraObj.Spec.PlatformSpec.VSphere.FailureDomains = make([]ocpv1.VSpherePlatformFailureDomainSpec, test.failureDomainCount)
+			for i := 0; i < test.failureDomainCount; i++ {
+				infraObj.Spec.PlatformSpec.VSphere.FailureDomains[i] = ocpv1.VSpherePlatformFailureDomainSpec{
+					Name:   "fd" + string(rune('1'+i)),
+					Region: "region1",
+					Zone:   "zone" + string(rune('1'+i)),
+					Server: "vcenter.example.com",
+					Topology: ocpv1.VSpherePlatformTopology{
+						Datacenter: "dc1",
+						Datastore:  "ds" + string(rune('1'+i)),
+					},
+				}
+			}
+
+			clusterCSIDriver := testlib.GetClusterCSIDriver(false)
+
+			// Get topology categories — this is what the topology hook uses
+			topologyCategories := utils.GetTopologyCategories(clusterCSIDriver, infraObj)
+
+			// Create a minimal deployment with a csi-provisioner container
+			deployment := &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Name: "csi-provisioner",
+									Args: []string{"--v=2"},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			// Simulate the topology hook behavior
+			if len(topologyCategories) > 0 {
+				containers := deployment.Spec.Template.Spec.Containers
+				for i := range containers {
+					if containers[i].Name == "csi-provisioner" {
+						containers[i].Args = append(containers[i].Args, "--feature-gates=Topology=true", "--strict-topology")
+					}
+				}
+			}
+
+			// Verify
+			provisionerArgs := deployment.Spec.Template.Spec.Containers[0].Args
+			hasTopologyArg := false
+			for _, arg := range provisionerArgs {
+				if arg == "--feature-gates=Topology=true" {
+					hasTopologyArg = true
+					break
+				}
+			}
+
+			if test.expectTopologyArgs && !hasTopologyArg {
+				t.Error("expected topology args but none found")
+			}
+			if !test.expectTopologyArgs && hasTopologyArg {
+				t.Error("did not expect topology args but found them")
+			}
+		})
+	}
+}
+
+// TestTopologyHookSequence verifies topology transitions across a sequence of
+// failure domain count changes: 2 FD → 1 FD → 2 FD → 0 FD
+func TestTopologyHookSequence(t *testing.T) {
+	fdCounts := []int{2, 1, 2, 0}
+	expectedTopology := []bool{true, false, true, false}
+
+	for step, fdCount := range fdCounts {
+		infraObj := testlib.GetInfraObject()
+		if infraObj.Spec.PlatformSpec.VSphere == nil {
+			infraObj.Spec.PlatformSpec.VSphere = &ocpv1.VSpherePlatformSpec{}
+		}
+		infraObj.Spec.PlatformSpec.VSphere.FailureDomains = make([]ocpv1.VSpherePlatformFailureDomainSpec, fdCount)
+		for i := 0; i < fdCount; i++ {
+			infraObj.Spec.PlatformSpec.VSphere.FailureDomains[i] = ocpv1.VSpherePlatformFailureDomainSpec{
+				Name:   "fd",
+				Region: "r",
+				Zone:   "z",
+				Server: "vc",
+				Topology: ocpv1.VSpherePlatformTopology{
+					Datacenter: "dc",
+					Datastore:  "ds",
+				},
+			}
+		}
+
+		clusterCSIDriver := testlib.GetClusterCSIDriver(false)
+		topologyCategories := utils.GetTopologyCategories(clusterCSIDriver, infraObj)
+
+		// Fresh deployment each sync (simulating library-go manifest base)
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: v1.PodTemplateSpec{
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{Name: "csi-provisioner", Args: []string{"--v=2"}},
+						},
+					},
+				},
+			},
+		}
+
+		if len(topologyCategories) > 0 {
+			deployment.Spec.Template.Spec.Containers[0].Args = append(
+				deployment.Spec.Template.Spec.Containers[0].Args,
+				"--feature-gates=Topology=true", "--strict-topology",
+			)
+		}
+
+		hasTopology := false
+		for _, arg := range deployment.Spec.Template.Spec.Containers[0].Args {
+			if arg == "--feature-gates=Topology=true" {
+				hasTopology = true
+			}
+		}
+
+		if hasTopology != expectedTopology[step] {
+			t.Errorf("step %d (FD count=%d): expected topology=%v, got %v", step, fdCount, expectedTopology[step], hasTopology)
+		}
+	}
+}
+

--- a/pkg/operator/vspherecontroller/vspherecontroller.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller.go
@@ -56,6 +56,7 @@ type VSphereController struct {
 	storageClassController   storageclasscontroller.StorageClassSyncInterface
 	operandControllerStarted bool
 	vSphereConnection        *vclib.VSphereConnection
+	connectionManager        *vclib.VSphereConnectionManager
 	csiConfigManifest        []byte
 	vSphereChecker           vSphereEnvironmentCheckInterface
 	// creates a new vSphereConnection - mainly used for testing
@@ -194,15 +195,48 @@ func (c *VSphereController) sync(ctx context.Context, syncContext factory.SyncCo
 	} else {
 		connectionResult = c.loginToVCenter(ctx, infra)
 	}
+
+	// Build a connection manager for multi-vCenter support.
+	// When only one vCenter is present this is a thin wrapper around the single connection.
+	if connectionResult.CheckError == nil && c.vsphereConnectionFunc == nil {
+		connMgr, err := c.createMultiVCenterConnections(ctx, infra)
+		if err != nil {
+			klog.Errorf("Failed to build multi-vCenter connections: %v", err)
+			// Non-fatal for now — fall back to single connection
+		} else {
+			connErrs := connMgr.ConnectAll(ctx)
+			primaryOK := true
+			for _, connErr := range connErrs {
+				if connErr.Host == connMgr.PrimaryHost() {
+					primaryOK = false
+					klog.Errorf("Primary vCenter %s connection failed: %v", connErr.Host, connErr.Err)
+				} else {
+					klog.Warningf("Secondary vCenter %s connection failed (non-degrading): %v", connErr.Host, connErr.Err)
+				}
+			}
+			if primaryOK {
+				c.connectionManager = connMgr
+				// Primary connection is the same as the single connection for backward compat
+				if primary := connMgr.GetPrimary(); primary != nil {
+					c.vSphereConnection = primary
+				}
+			}
+		}
+	}
+
 	defer func() {
 		klog.V(4).Infof("%s: vcenter-csi logging out from vcenter", c.name)
-		if c.vSphereConnection != nil && logout {
+		// Logout from all connections via manager if available
+		if c.connectionManager != nil {
+			c.connectionManager.LogoutAll(ctx)
+			c.connectionManager = nil
+		} else if c.vSphereConnection != nil && logout {
 			err := c.vSphereConnection.Logout(ctx)
 			if err != nil {
 				klog.Errorf("%s: error closing connection to vCenter API: %v", c.name, err)
 			}
-			c.vSphereConnection = nil
 		}
+		c.vSphereConnection = nil
 	}()
 
 	blockCSIDriverInstall, err := c.installCSIDriver(ctx, syncContext, infra, clusterCSIDriver, connectionResult, opStatus)
@@ -213,7 +247,14 @@ func (c *VSphereController) sync(ctx context.Context, syncContext factory.SyncCo
 	// only install CSI storageclass if blockCSIDriverInstall is false and CSI driver has been installed.
 	if !blockCSIDriverInstall && c.operandControllerStarted {
 		storageClassAPIDeps := c.getCheckAPIDependency(infra)
-		err = c.storageClassController.Sync(ctx, c.vSphereConnection, storageClassAPIDeps)
+		// Use the connection manager if available, otherwise create a single-connection wrapper
+		syncConnMgr := c.connectionManager
+		if syncConnMgr == nil && c.vSphereConnection != nil {
+			syncConnMgr = vclib.NewVSphereConnectionManager()
+			syncConnMgr.AddConnection(c.vSphereConnection.Hostname, c.vSphereConnection)
+			syncConnMgr.SetPrimary(c.vSphereConnection.Hostname)
+		}
+		err = c.storageClassController.Sync(ctx, syncConnMgr, storageClassAPIDeps)
 		// storageclass sync will only return error if somehow updating conditions fails, in which case
 		// we can return error here and degrade the cluster
 		if err != nil {
@@ -437,6 +478,113 @@ func (c *VSphereController) createVCenterConnection(ctx context.Context, infra *
 	return nil
 }
 
+// createMultiVCenterConnections builds a VSphereConnectionManager from the Infrastructure
+// spec. If the spec contains multiple VCenters or failure domains referencing multiple
+// servers, connections are created for each. Falls back to single-connection behavior
+// when only one vCenter is present.
+func (c *VSphereController) createMultiVCenterConnections(ctx context.Context, infra *ocpv1.Infrastructure) (*vclib.VSphereConnectionManager, error) {
+	klog.V(3).Infof("Creating multi-vCenter connections")
+
+	// Parse cloud config to get the workspace vCenter and VSphereConfig
+	cloudConfig := infra.Spec.CloudConfig
+	cloudConfigMap, err := c.configMapLister.ConfigMaps(cloudConfigNamespace).Get(cloudConfig.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cloud config: %v", err)
+	}
+
+	cfgString, ok := cloudConfigMap.Data[infra.Spec.CloudConfig.Key]
+	if !ok {
+		return nil, fmt.Errorf("cloud config %s/%s does not contain key %q", cloudConfigNamespace, cloudConfig.Name, cloudConfig.Key)
+	}
+	cfg := new(vsphere.VSphereConfig)
+	err = gcfg.ReadStringInto(cfg, cfgString)
+	if err != nil {
+		return nil, err
+	}
+
+	// Read credentials secret
+	secret, err := c.secretLister.Secrets(c.targetNamespace).Get(cloudCredSecretName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Collect unique vCenter hostnames from VCenters list or FailureDomains
+	vcenterHosts := collectVCenterHosts(infra)
+
+	// If no VCenters or FDs specified, fall back to workspace vCenter
+	if len(vcenterHosts) == 0 {
+		vcenterHosts = []string{cfg.Workspace.VCenterIP}
+	}
+
+	connMgr := vclib.NewVSphereConnectionManager()
+	connMgr.SetPrimary(cfg.Workspace.VCenterIP)
+
+	// Validate that the workspace vCenter is in the VCenters list
+	primaryFound := false
+	for _, host := range vcenterHosts {
+		if host == cfg.Workspace.VCenterIP {
+			primaryFound = true
+			break
+		}
+	}
+	if !primaryFound {
+		return nil, fmt.Errorf("workspace vCenter %q is not in the Infrastructure VCenters or FailureDomains list; this is an invalid configuration", cfg.Workspace.VCenterIP)
+	}
+
+	for _, host := range vcenterHosts {
+		userKey := host + ".username"
+		username, ok := secret.Data[userKey]
+		if !ok {
+			return nil, fmt.Errorf("error parsing secret %q: key %q not found", cloudCredSecretName, userKey)
+		}
+		passwordKey := host + ".password"
+		password, ok := secret.Data[passwordKey]
+		if !ok {
+			return nil, fmt.Errorf("error parsing secret %q: key %q not found", cloudCredSecretName, passwordKey)
+		}
+
+		// Create a per-vCenter config by copying the base config
+		vcCfg := *cfg
+		vcCfg.Workspace.VCenterIP = host
+
+		conn := vclib.NewVSphereConnection(string(username), string(password), &vcCfg)
+		connMgr.AddConnection(host, conn)
+	}
+
+	return connMgr, nil
+}
+
+// collectVCenterHosts returns the unique set of vCenter hostnames from Infrastructure spec.
+// It checks VCenters first; if empty, collects unique Server values from FailureDomains.
+func collectVCenterHosts(infra *ocpv1.Infrastructure) []string {
+	if infra.Spec.PlatformSpec.VSphere == nil {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	var hosts []string
+
+	// Prefer VCenters list
+	if len(infra.Spec.PlatformSpec.VSphere.VCenters) > 0 {
+		for _, vc := range infra.Spec.PlatformSpec.VSphere.VCenters {
+			if _, exists := seen[vc.Server]; !exists {
+				seen[vc.Server] = struct{}{}
+				hosts = append(hosts, vc.Server)
+			}
+		}
+		return hosts
+	}
+
+	// Fallback: collect unique servers from FailureDomains
+	for _, fd := range infra.Spec.PlatformSpec.VSphere.FailureDomains {
+		if _, exists := seen[fd.Server]; !exists {
+			seen[fd.Server] = struct{}{}
+			hosts = append(hosts, fd.Server)
+		}
+	}
+	return hosts
+}
+
 func (c *VSphereController) updateConditions(
 	ctx context.Context,
 	name string,
@@ -570,6 +718,15 @@ func (c *VSphereController) applyClusterCSIDriverChange(
 	clusterCSIDriver *operatorapi.ClusterCSIDriver,
 	datastoreURL string) (*corev1.ConfigMap, error) {
 
+	// Collect unique vCenter hosts from VCenters list or FailureDomains
+	vcenterHosts := collectVCenterHosts(infra)
+
+	// If multiple vCenters exist, use programmatic INI construction
+	if len(vcenterHosts) > 1 {
+		return c.applyMultiVCenterCSIDriverChange(infra, sourceCFG, clusterCSIDriver, datastoreURL, vcenterHosts)
+	}
+
+	// Single vCenter path: use template-based approach (backward compatible)
 	csiConfigString := string(c.csiConfigManifest)
 
 	dataCenterNames, err := utils.GetDatacenters(&sourceCFG)
@@ -608,6 +765,107 @@ func (c *VSphereController) applyClusterCSIDriverChange(
 	requiredCM.Data["cloud.conf"] = finalConfigString.String()
 	return requiredCM, nil
 
+}
+
+// applyMultiVCenterCSIDriverChange constructs a CSI config with multiple [VirtualCenter] sections.
+func (c *VSphereController) applyMultiVCenterCSIDriverChange(
+	infra *ocpv1.Infrastructure,
+	sourceCFG vsphere.VSphereConfig,
+	clusterCSIDriver *operatorapi.ClusterCSIDriver,
+	datastoreURL string,
+	vcenterHosts []string) (*corev1.ConfigMap, error) {
+
+	csiConfig := iniv1.Empty()
+
+	// [Global] section
+	globalSection := csiConfig.Section("Global")
+	globalSection.Key("cluster-id").SetValue(infra.Status.InfrastructureName)
+
+	// Build per-vCenter sections
+	for _, host := range vcenterHosts {
+		sectionName := fmt.Sprintf("VirtualCenter \"%s\"", host)
+		vcSection := csiConfig.Section(sectionName)
+		vcSection.Key("insecure-flag").SetValue("true")
+
+		// Collect datacenters from failure domains for this vCenter
+		var dcs []string
+		dcSeen := make(map[string]bool)
+		if infra.Spec.PlatformSpec.VSphere != nil {
+			for _, fd := range infra.Spec.PlatformSpec.VSphere.FailureDomains {
+				if fd.Server == host {
+					dc := fd.Topology.Datacenter
+					if dc != "" && !dcSeen[dc] {
+						dcs = append(dcs, dc)
+						dcSeen[dc] = true
+					}
+				}
+			}
+		}
+
+		// Fallback: check VCenters spec for datacenters
+		if len(dcs) == 0 && infra.Spec.PlatformSpec.VSphere != nil {
+			for _, vc := range infra.Spec.PlatformSpec.VSphere.VCenters {
+				if vc.Server == host {
+					dcs = vc.Datacenters
+					break
+				}
+			}
+		}
+
+		// Last fallback: use config file's VirtualCenter entry
+		if len(dcs) == 0 {
+			if vcConfig, ok := sourceCFG.VirtualCenter[host]; ok {
+				for _, dc := range strings.Split(vcConfig.Datacenters, ",") {
+					dc = strings.TrimSpace(dc)
+					if dc != "" {
+						dcs = append(dcs, dc)
+					}
+				}
+			}
+		}
+
+		if len(dcs) > 0 {
+			vcSection.Key("datacenters").SetValue(strings.Join(dcs, ","))
+		}
+
+		// Set migration-datastore-url for the primary (workspace) vCenter
+		if host == sourceCFG.Workspace.VCenterIP && datastoreURL != "" {
+			vcSection.Key("migration-datastore-url").SetValue(datastoreURL)
+		}
+	}
+
+	// [Labels] section for topology
+	topologyCategories := utils.GetTopologyCategories(clusterCSIDriver, infra)
+	if len(topologyCategories) > 0 {
+		topologyCategoryString := strings.Join(topologyCategories, ",")
+		csiConfig.Section("Labels").Key("topology-categories").SetValue(topologyCategoryString)
+	}
+
+	// Serialize and validate
+	var configString strings.Builder
+	_, err := csiConfig.WriteTo(&configString)
+	if err != nil {
+		return nil, fmt.Errorf("error serializing CSI config: %v", err)
+	}
+
+	// Parse-back validation: ensure the generated INI is valid
+	validationCfg := new(vsphere.VSphereConfig)
+	err = gcfg.ReadStringInto(validationCfg, configString.String())
+	if err != nil {
+		return nil, fmt.Errorf("generated CSI config failed validation: %v", err)
+	}
+
+	// Validate that every VirtualCenter section has non-empty datacenters
+	for host := range validationCfg.VirtualCenter {
+		vcConfig := validationCfg.VirtualCenter[host]
+		if vcConfig == nil || strings.TrimSpace(vcConfig.Datacenters) == "" {
+			return nil, fmt.Errorf("generated CSI config has empty datacenters for VirtualCenter %q", host)
+		}
+	}
+
+	requiredCM := resourceread.ReadConfigMapV1OrDie(c.manifest)
+	requiredCM.Data["cloud.conf"] = configString.String()
+	return requiredCM, nil
 }
 
 func (c *VSphereController) createStorageClassController() storageclasscontroller.StorageClassSyncInterface {

--- a/pkg/operator/vspherecontroller/vspherecontroller_test.go
+++ b/pkg/operator/vspherecontroller/vspherecontroller_test.go
@@ -69,7 +69,7 @@ type dummyStorageClassController struct {
 	syncCalled int
 }
 
-func (c *dummyStorageClassController) Sync(ctx context.Context, connection *vclib.VSphereConnection, apiDeps checks.KubeAPIInterface) error {
+func (c *dummyStorageClassController) Sync(ctx context.Context, connMgr *vclib.VSphereConnectionManager, apiDeps checks.KubeAPIInterface) error {
 	c.syncCalled += 1
 	return nil
 }
@@ -474,18 +474,19 @@ func TestApplyClusterCSIDriver(t *testing.T) {
 			expectedTopology:   "k8s-zone,k8s-region",
 		},
 		{
-			name:             "when configuration has more than one vcenter",
-			clusterCSIDriver: testlib.GetClusterCSIDriver(true),
-			operatorObj:      testlib.MakeFakeDriverInstance(),
-			configFileName:   "multiple_vc.ini",
-			expectError:      true,
+			name:               "when configuration has more than one vcenter",
+			clusterCSIDriver:   testlib.GetClusterCSIDriver(true),
+			operatorObj:        testlib.MakeFakeDriverInstance(),
+			configFileName:     "multiple_vc.ini",
+			expectedDatacenter: "Datacenter,Datacenterb",
+			expectedTopology:   "k8s-zone,k8s-region",
 		},
 		{
 			name:               "when configuration has more than one datacenter",
 			clusterCSIDriver:   testlib.GetClusterCSIDriver(true),
 			operatorObj:        testlib.MakeFakeDriverInstance(),
 			configFileName:     "multiple_dc.ini",
-			expectedDatacenter: "Datacentera, DatacenterB",
+			expectedDatacenter: "Datacentera,DatacenterB",
 			expectedTopology:   "k8s-zone,k8s-region",
 		},
 	}


### PR DESCRIPTION
This implements Phases 1, 2, and 3A of the failure domain lifecycle plan:

Phase 1: Fix StorageClassController backoff — reset to 1-minute interval on success instead of permanently staying at the 30-minute cap.

Phase 2: Multi-vCenter connection support — add VSphereConnectionManager for concurrent connections to multiple vCenters, plumb it through StorageClassController and storage policy API so tag/profile operations resolve the correct connection per failure domain. Remove the single- VirtualCenter enforcement in GetDatacenters(). Generate multi-section CSI config INI with parse-back validation. Update credential injection to handle multi-vCenter secrets gracefully.

Phase 3A: Single-vCenter orphan tag cleanup — detect datastores tagged with the cluster tag that are no longer in any failure domain, detach orphan tags with PV safety (skip detach when CNS volumes are backed by the datastore), add tag operation and orphan detection metrics, and integrate cleanup into both zonal and non-zonal storage policy paths to handle the 2+ FD → 0 FD transition. Add topology mode transition verification tests confirming the hook correctly drops topology args when failure domains decrease below 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-vCenter support with improved connection management and lifecycle handling.
  * Introduced orphan tag detection and cleanup for storage policies.
  * Added new metrics for monitoring tag operations.

* **Bug Fixes**
  * Improved datacenter configuration handling across multiple vCenters.

* **Tests**
  * Added comprehensive test coverage for connection manager and topology datacenter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->